### PR TITLE
Harden forum database integrity

### DIFF
--- a/forum/models.py
+++ b/forum/models.py
@@ -4,20 +4,20 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PostCreate(BaseModel):
-    author: str
-    title: str
-    content: str
+    author: str = Field(..., min_length=1, max_length=100)
+    title: str = Field(..., min_length=1, max_length=200)
+    content: str = Field(..., min_length=1, max_length=50000)
     category: str = "discussion"
     tags: List[str] = []
 
 
 class CommentCreate(BaseModel):
-    author: str
-    content: str
+    author: str = Field(..., min_length=1, max_length=100)
+    content: str = Field(..., min_length=1, max_length=50000)
     parent_id: Optional[int] = None
 
 


### PR DESCRIPTION
## Summary
- **WAL mode**: Enable WAL journal mode on forum SQLite for better concurrent read performance (chat.js already does this)
- **Foreign keys**: Enable `PRAGMA foreign_keys = ON` so FK constraints are actually enforced at runtime (SQLite ignores them by default)
- **Unique vote constraint**: Add unique indexes on `(post_id, author)` and `(comment_id, author)` to prevent duplicate votes from race conditions between SELECT and INSERT
- **Input validation**: Add length constraints on Pydantic models — title max 200 chars, content max 50K, author max 100

## Test plan
- [ ] Verify forum starts without errors (existing DBs get new indexes automatically)
- [ ] Create a post — should work as before
- [ ] Try voting twice on same post with same author — second should toggle/update, not duplicate
- [ ] Try creating a post with empty title — should get 422 validation error
- [ ] Check forum DB has WAL mode: `sqlite3 <db> "PRAGMA journal_mode"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)