### PR TITLE
Show unread chats and pending reminders in orient

### DIFF
--- a/harness/orient.sh
+++ b/harness/orient.sh
@@ -47,6 +47,20 @@ check_service "Hub" "http://127.0.0.1:${HUB_PORT}/"
 HS_PORT=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('services',{}).get('hammerspoon',{}).get('port',8097))" 2>/dev/null || echo 8097)
 check_service "Hammerspoon" "http://127.0.0.1:${HS_PORT}/health"
 
+# Unread chat messages
+UNREAD=$(curl -s --max-time 2 "http://127.0.0.1:${HUB_PORT}/api/chat?mode=unread" 2>/dev/null)
+UNREAD_COUNT=$(echo "$UNREAD" | python3 -c "import sys,json; print(json.load(sys.stdin).get('count',0))" 2>/dev/null || echo 0)
+if [ "$UNREAD_COUNT" -gt 0 ] 2>/dev/null; then
+    echo -e "\n\033[1;33mChat:\033[0m $UNREAD_COUNT unread message(s) — check with read_messages"
+fi
+
+# Pending reminders
+PENDING=$(curl -s --max-time 2 "http://127.0.0.1:${NOTIF_PORT}/pending" 2>/dev/null)
+PENDING_COUNT=$(echo "$PENDING" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+if [ "$PENDING_COUNT" -gt 0 ] 2>/dev/null; then
+    echo -e "\033[1;33mReminders:\033[0m $PENDING_COUNT due"
+fi
+
 # Disk
 DISK_USED=$(df -h ~ 2>/dev/null | awk 'NR==2{print $5}')
 echo -e "\n\033[0;34mDisk:\033[0m ${DISK_USED:-unknown}"


### PR DESCRIPTION
## Summary
- **Unread chat messages**: Orient now checks the hub chat API for unread messages and shows a count. This ensures the agent doesn't miss owner messages on startup.
- **Pending reminders**: Shows count of due reminders from the notifications service.

Both checks use 2-second curl timeouts so orient stays fast even if services are down. Output only appears when there are unread messages or due reminders (no noise when everything is clear).

## Test plan
- [ ] Run `relaygent orient` with no unread messages — should show normal output (no chat line)
- [ ] Send a chat message via the dashboard, then run orient — should show "1 unread message(s)"
- [ ] Set a reminder in the past, run orient — should show "1 due"
- [ ] Stop the hub service, run orient — should not error (curl timeout is silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)