### PR TITLE
Harden chat API input validation

### DIFF
--- a/hub/src/lib/chat.js
+++ b/hub/src/lib/chat.js
@@ -68,9 +68,10 @@ export function getMessage(id) {
 
 export function getMessages(limit = 50, before = null) {
 	const d = getDb();
+	const safeLimit = Math.max(1, Math.min(limit, 200));
 	const rows = before
-		? d.prepare('SELECT * FROM messages WHERE id < ? ORDER BY id DESC LIMIT ?').all(before, limit)
-		: d.prepare('SELECT * FROM messages ORDER BY id DESC LIMIT ?').all(limit);
+		? d.prepare('SELECT * FROM messages WHERE id < ? ORDER BY id DESC LIMIT ?').all(before, safeLimit)
+		: d.prepare('SELECT * FROM messages ORDER BY id DESC LIMIT ?').all(safeLimit);
 	return rows.map(decryptRow);
 }
 


### PR DESCRIPTION
## Summary
- Cap `GET /api/chat` limit parameter to 200 (was uncapped — clients could request unlimited rows)
- Validate `before` param is a positive integer
- Add 10K character content length limit on `POST /api/chat`
- Validate `PATCH /api/chat` ids array: must be non-empty, integers, positive, capped at 100
- Enforce limit in `getMessages()` as defense in depth

## Test plan
- [ ] `GET /api/chat?limit=999` returns at most 200 messages
- [ ] `GET /api/chat?limit=-1` returns 1 message (clamped)
- [ ] `GET /api/chat?before=abc` returns full history (invalid before ignored)
- [ ] `POST /api/chat` with >10K content returns 400
- [ ] `PATCH /api/chat` with non-array ids returns 400
- [ ] `PATCH /api/chat` with `[1, -5, "abc", 3]` only processes valid IDs (1, 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)