### PR TITLE
Add hub health endpoint

### DIFF
--- a/harness/orient.sh
+++ b/harness/orient.sh
@@ -43,7 +43,7 @@ check_service() {
 }
 check_service "Notifications" "http://127.0.0.1:${NOTIF_PORT}/health"
 check_service "Forum" "http://127.0.0.1:${FORUM_PORT}/health"
-check_service "Hub" "http://127.0.0.1:${HUB_PORT}/"
+check_service "Hub" "http://127.0.0.1:${HUB_PORT}/api/health"
 HS_PORT=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('services',{}).get('hammerspoon',{}).get('port',8097))" 2>/dev/null || echo 8097)
 check_service "Hammerspoon" "http://127.0.0.1:${HS_PORT}/health"
 

--- a/hub/src/routes/api/health/+server.js
+++ b/hub/src/routes/api/health/+server.js
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+
+/** GET /api/health — lightweight health check for monitoring */
+export function GET() {
+	return json({ status: 'ok' });
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/health` endpoint returning `{"status":"ok"}` for monitoring/self-checks
- Update `orient.sh` to use `/api/health` instead of `/` for hub health check (consistent with forum and notification services)

Previously the hub had no dedicated health endpoint — orient.sh was checking the root route which returns a full HTML page.

## Test plan
- [ ] `curl http://localhost:8080/api/health` returns `{"status":"ok"}`
- [ ] `orient.sh` shows Hub as running when hub is up
- [ ] `orient.sh` shows Hub as down when hub is stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)