### PR TITLE
Fix recurring reminders missed during polling gaps

### DIFF
--- a/notifications/reminders.py
+++ b/notifications/reminders.py
@@ -97,8 +97,12 @@ def fire_reminder(reminder_id):
         return jsonify({"status": "fired"})
 
 
-def is_recurring_reminder_due(recurrence, last_trigger_time, window_minutes=5):
+def is_recurring_reminder_due(recurrence, last_trigger_time):
     """Check if recurring reminder should fire now.
+
+    Compares most recent cron occurrence against last_trigger_time.
+    If the last occurrence is newer than when we last fired, it's due.
+    No time window — reminders can't be missed due to polling gaps.
 
     Returns (is_due, prev_occurrence_iso).
     """
@@ -109,10 +113,7 @@ def is_recurring_reminder_due(recurrence, last_trigger_time, window_minutes=5):
     cron = croniter(recurrence, now)
     prev_occurrence = cron.get_prev(datetime)
 
-    minutes_since = (now - prev_occurrence).total_seconds() / 60
-    if minutes_since > window_minutes:
-        return False, ""
-
+    # Only fire if this occurrence hasn't been fired yet
     if last_trigger_time:
         last_trigger_dt = datetime.fromisoformat(last_trigger_time)
         if last_trigger_dt >= prev_occurrence:


### PR DESCRIPTION
## Summary
- Recurring reminders used a 5-minute window: if the cron occurrence was >5 min ago, it was silently skipped forever
- Now compares directly against `last_trigger_time` — if we haven't fired for this occurrence, it's due
- No more missed reminders regardless of polling gap duration

## The bug
```
Cron: every hour at :00
Last polled: 2:58 AM (fires 2:00 occurrence, updates trigger_time)
Polling stops (relay restarting, etc.)
Polling resumes: 3:08 AM
Old behavior: 3:00 occurrence is 8 min old > 5 min window → SKIPPED permanently
New behavior: 3:00 > last_trigger(2:00) → fires correctly
```

## Test plan
- [ ] Verify recurring reminders still fire within normal polling intervals
- [ ] Verify a reminder isn't fired twice for the same occurrence
- [ ] Verify a missed occurrence fires when polling resumes after a gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)