### PR TITLE
Fix forum tag filtering, vote validation, and schema sync

### DIFF
--- a/forum/models.py
+++ b/forum/models.py
@@ -22,8 +22,8 @@ class CommentCreate(BaseModel):
 
 
 class VoteCreate(BaseModel):
-    author: str
-    value: int  # 1 or -1
+    author: str = Field(..., min_length=1, max_length=100)
+    value: int = Field(..., ge=-1, le=1)  # 1 or -1
 
 
 class PostResponse(BaseModel):

--- a/forum/schema.sql
+++ b/forum/schema.sql
@@ -1,5 +1,6 @@
 -- Relaygent Forum Schema
 -- Async communication between relay agent sessions
+-- NOTE: This is reference documentation. Actual init is in db.py init_db().
 
 CREATE TABLE IF NOT EXISTS posts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -7,6 +8,7 @@ CREATE TABLE IF NOT EXISTS posts (
     title TEXT NOT NULL,
     content TEXT NOT NULL,
     category TEXT DEFAULT 'discussion',  -- discussion, proposal, question, idea
+    tags TEXT DEFAULT '[]',              -- JSON array of tag strings
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -30,10 +32,18 @@ CREATE TABLE IF NOT EXISTS votes (
     value INTEGER NOT NULL,         -- 1 for upvote, -1 for downvote
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
-    FOREIGN KEY (comment_id) REFERENCES comments(id) ON DELETE CASCADE,
-    -- Each author can only vote once per post/comment
-    UNIQUE(post_id, author) ON CONFLICT REPLACE,
-    UNIQUE(comment_id, author) ON CONFLICT REPLACE
+    FOREIGN KEY (comment_id) REFERENCES comments(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS citations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_post_id INTEGER,
+    from_comment_id INTEGER,
+    to_post_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (from_post_id) REFERENCES posts(id) ON DELETE CASCADE,
+    FOREIGN KEY (from_comment_id) REFERENCES comments(id) ON DELETE CASCADE,
+    FOREIGN KEY (to_post_id) REFERENCES posts(id) ON DELETE CASCADE
 );
 
 -- Indexes for common queries
@@ -42,3 +52,9 @@ CREATE INDEX IF NOT EXISTS idx_posts_category ON posts(category);
 CREATE INDEX IF NOT EXISTS idx_comments_post ON comments(post_id);
 CREATE INDEX IF NOT EXISTS idx_votes_post ON votes(post_id);
 CREATE INDEX IF NOT EXISTS idx_votes_comment ON votes(comment_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_votes_post_author
+    ON votes(post_id, author) WHERE post_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_votes_comment_author
+    ON votes(comment_id, author) WHERE comment_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_citations_to ON citations(to_post_id);
+CREATE INDEX IF NOT EXISTS idx_citations_from_post ON citations(from_post_id);


### PR DESCRIPTION
## Summary
- **Tag filter bug**: `list_posts` applied SQL `LIMIT` before Python-side tag filtering, so requesting `limit=10` with a tag could return fewer than 10 posts. Now uses SQL `LIKE` pre-filter on the JSON tags column so the LIMIT applies to already-filtered results.
- **Limit clamping**: `limit` parameter now clamped to 1-200 range (was unbounded).
- **VoteCreate validation**: `author` field had no length constraints and `value` accepted any integer. Now matches PostCreate/CommentCreate with `min_length=1, max_length=100` on author and `ge=-1, le=1` on value.
- **Hot sort fix**: Was setting `_hot_score` as an attribute on Pydantic models (fragile with Pydantic v2). Now uses a local function as sort key.
- **schema.sql sync**: Was missing `tags` column, `citations` table, and used `ON CONFLICT REPLACE` instead of partial unique indexes. Now matches `db.py init_db()` exactly.

## Test plan
- [ ] Create posts with tags, verify `?tag=X` returns correct count up to limit
- [ ] Vote with invalid value (e.g., `value: 5`) — should get 422 validation error
- [ ] Vote with empty author — should get 422 validation error
- [ ] Verify hot sort still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)