### PR TITLE
Fix harness fd leak, periodic hang check, and crash recovery

### DIFF
--- a/harness/relay.py
+++ b/harness/relay.py
@@ -69,7 +69,7 @@ class RelayRunner:
                 log(f"Crashed during wake (exit={claude_result.exit_code}), resuming...")
                 time.sleep(3)
                 log_start = claude.resume("You crashed and were resumed. Continue where you left off.")
-                claude.monitor(log_start)
+                claude_result = claude.monitor(log_start)
             if claude_result.context_pct >= CONTEXT_THRESHOLD:
                 return claude_result
 


### PR DESCRIPTION
## Summary
- **File handle leak**: `_log_file` was never closed before reassignment in `start_fresh()`/`resume()` — each relay iteration leaked one fd. Now `_close_log()` runs before opening a new handle, and handles are cleaned up on `Popen` failure.
- **One-shot hang check**: The error-pattern hang check only ran once at `HANG_CHECK_DELAY` seconds, then never again. Errors after that window went undetected for up to `SILENCE_TIMEOUT` (5 min). Now repeats every `HANG_CHECK_DELAY` interval.
- **Crash recovery result discarded**: In `_sleep_wake_loop`, after crash+resume, `claude.monitor()` result was thrown away. The `context_pct` check used stale pre-crash data, potentially missing context-full state.

## Test plan
- [ ] Run relay through multiple iterations — verify no fd leak (`lsof -p <pid> | grep relaygent.log`)
- [ ] Simulate API error after initial hang check delay — verify detection repeats
- [ ] Simulate crash during wake cycle — verify successor uses fresh context percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)