### PR TITLE
Validate IDs in hub API proxy routes to prevent SSRF

### DIFF
--- a/hub/src/routes/api/forum/posts/[id]/comments/+server.js
+++ b/hub/src/routes/api/forum/posts/[id]/comments/+server.js
@@ -1,6 +1,10 @@
+import { json } from '@sveltejs/kit';
 const FORUM_API = `http://localhost:${process.env.RELAYGENT_FORUM_PORT || '8085'}`;
 
 export async function POST({ request, params }) {
+	if (!/^\d+$/.test(params.id)) {
+		return json({ error: 'Invalid post ID' }, { status: 400 });
+	}
 	const body = await request.json();
 	const res = await fetch(`${FORUM_API}/posts/${params.id}/comments`, {
 		method: 'POST',

--- a/hub/src/routes/api/notifications/+server.js
+++ b/hub/src/routes/api/notifications/+server.js
@@ -37,7 +37,7 @@ export async function POST({ request }) {
 /** DELETE /api/notifications — cancel a reminder by id */
 export async function DELETE({ url }) {
 	const id = url.searchParams.get('id');
-	if (!id) return json({ error: 'id required' }, { status: 400 });
+	if (!id || !/^\d+$/.test(id)) return json({ error: 'valid numeric id required' }, { status: 400 });
 	try {
 		const result = await proxy(`/reminder/${id}`, 'DELETE');
 		return json(result);

--- a/hub/src/routes/forum/[id]/+page.server.js
+++ b/hub/src/routes/forum/[id]/+page.server.js
@@ -1,6 +1,9 @@
 const FORUM_API = `http://localhost:${process.env.RELAYGENT_FORUM_PORT || '8085'}`;
 
 export async function load({ params }) {
+	if (!/^\d+$/.test(params.id)) {
+		return { post: null, error: 'Invalid post ID' };
+	}
 	try {
 		const res = await fetch(`${FORUM_API}/posts/${params.id}`);
 		if (!res.ok) {


### PR DESCRIPTION
## Summary
- Route parameters and query params were interpolated directly into internal fetch URLs without validation. A crafted ID like `../../other/path` could redirect requests to unintended internal endpoints.
- Added numeric-only validation (`/^\d+$/`) to all ID parameters before URL interpolation:
  - `DELETE /api/notifications` — `id` query param
  - `GET /forum/[id]` — route param
  - `POST /api/forum/posts/[id]/comments` — route param

## Test plan
- [ ] Forum post pages still load correctly with valid numeric IDs
- [ ] Forum comments still post correctly
- [ ] Notification delete still works with valid IDs
- [ ] Non-numeric IDs return 400 error (e.g., `/forum/abc`, `/api/notifications?id=../foo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)