### PR TITLE
Fix token counting, orphan cleanup, and setup platform check

### DIFF
--- a/harness/relay_utils.py
+++ b/harness/relay_utils.py
@@ -34,10 +34,11 @@ def kill_orphaned_claudes() -> None:
         capture_output=True, text=True
     )
     if result.returncode == 0 and result.stdout.strip():
-        for pid in result.stdout.strip().split('\n'):
+        for pid_str in result.stdout.strip().split('\n'):
             try:
-                os.kill(int(pid), signal.SIGKILL)
-                log(f"Killed orphaned claude process {pid}")
+                pid = int(pid_str)
+                os.kill(pid, signal.SIGTERM)
+                log(f"Sent SIGTERM to orphaned claude process {pid}")
             except (ProcessLookupError, ValueError):
                 pass
 

--- a/hub/src/lib/relayStats.js
+++ b/hub/src/lib/relayStats.js
@@ -31,7 +31,7 @@ function parseSession(jsonlPath) {
 					turns++;
 					const usage = entry.message?.usage;
 					if (usage) {
-						totalTokens = (usage.input_tokens || 0)
+						totalTokens += (usage.input_tokens || 0)
 							+ (usage.cache_creation_input_tokens || 0)
 							+ (usage.cache_read_input_tokens || 0);
 						outputTokens += usage.output_tokens || 0;

--- a/setup-helpers.mjs
+++ b/setup-helpers.mjs
@@ -4,6 +4,10 @@ import { mkdirSync, writeFileSync, readFileSync, copyFileSync } from 'fs';
 import { join } from 'path';
 
 export function setupHammerspoon(config, REPO_DIR, HOME, C, ask) {
+	if (process.platform !== 'darwin') {
+		console.log(`  Hammerspoon: ${C.dim}skipped (macOS only)${C.reset}`);
+		return;
+	}
 	const hsDir = join(HOME, '.hammerspoon');
 	const srcDir = join(REPO_DIR, 'hammerspoon');
 	mkdirSync(hsDir, { recursive: true });
@@ -11,7 +15,6 @@ export function setupHammerspoon(config, REPO_DIR, HOME, C, ask) {
 		copyFileSync(join(srcDir, f), join(hsDir, f));
 	}
 	console.log(`  Hammerspoon: lua files installed to ${hsDir}`);
-	if (process.platform !== 'darwin') return;
 
 	const hs = spawnSync('open', ['-Ra', 'Hammerspoon'], { stdio: 'pipe' });
 	if (hs.status === 0) {


### PR DESCRIPTION
## Summary
- **relayStats.js token counting**: `totalTokens` was assigned (`=`) instead of accumulated (`+=`) per assistant turn. Only the last turn's input tokens were counted, causing `contextPct` to be underreported for multi-turn sessions.
- **relay_utils.py orphan cleanup**: `kill_orphaned_claudes` used `SIGKILL` as first resort. Changed to `SIGTERM` to allow graceful cleanup of leftover processes.
- **setup-helpers.mjs platform check**: Hammerspoon Lua files were copied to `~/.hammerspoon` unconditionally on all platforms including Linux. Now skips the entire Hammerspoon setup on non-macOS.

## Test plan
- [ ] Dashboard relay stats show accurate token counts across sessions
- [ ] `relaygent stop` followed by `relaygent start` — orphan cleanup uses SIGTERM
- [ ] Run `setup.mjs` on Linux — Hammerspoon step skipped cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)