### PR TITLE
Increase JSONL tail buffer and tighten orphan cleanup

### DIFF
--- a/harness/jsonl_checks.py
+++ b/harness/jsonl_checks.py
@@ -37,7 +37,7 @@ def get_jsonl_size(session_id: str, workspace: Path) -> int:
         return 0
 
 
-def _read_tail(jsonl: Path, bytes_count: int = 16384) -> list[str]:
+def _read_tail(jsonl: Path, bytes_count: int = 65536) -> list[str]:
     """Read last N bytes of a JSONL file and return lines."""
     try:
         with open(jsonl, 'rb') as f:
@@ -117,7 +117,7 @@ def get_context_fill_from_jsonl(session_id: str, workspace: Path) -> float:
     if not jsonl or not jsonl.exists():
         return 0.0
     try:
-        lines = _read_tail(jsonl, 8192)
+        lines = _read_tail(jsonl)
         for line in reversed(lines):
             if not line.strip():
                 continue

--- a/harness/relay_utils.py
+++ b/harness/relay_utils.py
@@ -28,16 +28,17 @@ def acquire_lock() -> int:
 
 
 def kill_orphaned_claudes() -> None:
-    """Kill any leftover claude --resume processes."""
+    """Kill any leftover claude --resume/--print processes."""
     result = subprocess.run(
-        ["pgrep", "-f", "claude --resume"],
+        ["pgrep", "-f", "claude.*--print.*--session-id"],
         capture_output=True, text=True
     )
     if result.returncode == 0 and result.stdout.strip():
-        for pid in result.stdout.strip().split('\n'):
+        for pid_str in result.stdout.strip().split('\n'):
             try:
-                os.kill(int(pid), signal.SIGKILL)
-                log(f"Killed orphaned claude process {pid}")
+                pid = int(pid_str)
+                os.kill(pid, signal.SIGTERM)
+                log(f"Sent SIGTERM to orphaned claude process {pid}")
             except (ProcessLookupError, ValueError):
                 pass
 


### PR DESCRIPTION
## Summary
- JSONL tail buffer: 16KB → 64KB. Large assistant messages (with tool results) could exceed 16KB, causing hang detection and context fill checks to miss the most recent entry. Also removed the 8KB override in `get_context_fill_from_jsonl`.
- Orphan cleanup pattern: `"claude --resume"` → `"claude.*--print.*--session-id"` — only matches relay-spawned processes, not unrelated claude invocations.
- Orphan cleanup: SIGKILL → SIGTERM for graceful shutdown.

## Test plan
- [ ] Verify hang detection still works with larger buffer
- [ ] Verify context fill percentage reads correctly
- [ ] Verify orphan cleanup doesn't kill non-relay claude processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)