### PR TITLE
Fix workspace name collision and include output_tokens in context fill

### DIFF
--- a/harness/config.py
+++ b/harness/config.py
@@ -39,7 +39,7 @@ def set_status(status: str) -> None:
 
 def get_workspace_dir() -> Path:
     """Create and return workspace directory for this run."""
-    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M")
+    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     workspace = RUNS_DIR / timestamp
     workspace.mkdir(parents=True, exist_ok=True)
     return workspace

--- a/harness/jsonl_checks.py
+++ b/harness/jsonl_checks.py
@@ -127,6 +127,7 @@ def get_context_fill_from_jsonl(session_id: str, workspace: Path) -> float:
                     usage = entry.get("message", {}).get("usage", {})
                     if usage:
                         total = (usage.get("input_tokens", 0)
+                                + usage.get("output_tokens", 0)
                                 + usage.get("cache_creation_input_tokens", 0)
                                 + usage.get("cache_read_input_tokens", 0))
                         return total / CONTEXT_WINDOW * 100

--- a/hooks/check-notifications
+++ b/hooks/check-notifications
@@ -56,7 +56,7 @@ for line in reversed(data.strip().split(chr(10))):
         if entry.get('type') == 'assistant':
             usage = entry.get('message', {}).get('usage', {})
             if usage:
-                total = usage.get('input_tokens', 0) + usage.get('cache_creation_input_tokens', 0) + usage.get('cache_read_input_tokens', 0)
+                total = usage.get('input_tokens', 0) + usage.get('output_tokens', 0) + usage.get('cache_creation_input_tokens', 0) + usage.get('cache_read_input_tokens', 0)
                 print(int(total / 200000 * 100))
                 break
     except: continue


### PR DESCRIPTION
## Summary
- Workspace directories now include seconds in the name (`%Y-%m-%d-%H-%M-%S` instead of `%Y-%m-%d-%H-%M`). Prevents directory reuse on fast restarts within the same minute.
- Context fill calculation now includes `output_tokens` — these also consume the context window, so excluding them underestimated fill percentage. Fixed in both `jsonl_checks.py` and `check-notifications` hook.

## Test plan
- [ ] Verify workspace directories include seconds in name
- [ ] Verify context fill percentage is slightly higher than before (now includes output tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)