### PR TITLE
Include bin/ and extensionless scripts in file length check

### DIFF
--- a/scripts/check-file-length.sh
+++ b/scripts/check-file-length.sh
@@ -8,28 +8,40 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 VIOLATIONS=0
 
-for dir in harness hub/src hooks notifications forum computer-use hammerspoon; do
-    full_path="$REPO_DIR/$dir"
-    [ -d "$full_path" ] || continue
-    while IFS= read -r file; do
-        lines=$(wc -l < "$file")
-        if [ "$lines" -gt "$MAX_LINES" ]; then
-            rel="${file#$REPO_DIR/}"
-            echo "FAIL: $rel ($lines lines, max $MAX_LINES)"
-            VIOLATIONS=$((VIOLATIONS + 1))
-        fi
-    done < <(find "$full_path" -type f \( -name '*.py' -o -name '*.js' -o -name '*.mjs' -o -name '*.svelte' -o -name '*.ts' \) ! -path '*/node_modules/*' ! -path '*/.svelte-kit/*' ! -path '*/build/*' ! -path '*/.venv/*')
-done
-
-# Also check top-level scripts
-for file in "$REPO_DIR"/setup.mjs "$REPO_DIR"/setup.sh "$REPO_DIR"/setup-helpers.mjs; do
-    [ -f "$file" ] || continue
+check_file() {
+    local file=$1
+    local lines
     lines=$(wc -l < "$file")
     if [ "$lines" -gt "$MAX_LINES" ]; then
         rel="${file#$REPO_DIR/}"
         echo "FAIL: $rel ($lines lines, max $MAX_LINES)"
         VIOLATIONS=$((VIOLATIONS + 1))
     fi
+}
+
+is_source_file() {
+    case "$1" in
+        *.py|*.js|*.mjs|*.svelte|*.ts|*.sh|*.bash) return 0 ;;
+    esac
+    # Extensionless files: check for shebang (scripts in bin/, hooks/)
+    case "$(basename "$1")" in
+        *.*) return 1 ;;  # has extension but not a known source type
+    esac
+    head -c 2 "$1" 2>/dev/null | grep -q '#!' && return 0
+    return 1
+}
+
+for dir in harness hub/src hooks notifications forum computer-use hammerspoon bin; do
+    full_path="$REPO_DIR/$dir"
+    [ -d "$full_path" ] || continue
+    while IFS= read -r file; do
+        is_source_file "$file" && check_file "$file"
+    done < <(find "$full_path" -type f ! -path '*/node_modules/*' ! -path '*/.svelte-kit/*' ! -path '*/build/*' ! -path '*/.venv/*')
+done
+
+# Also check top-level scripts
+for file in "$REPO_DIR"/setup.mjs "$REPO_DIR"/setup.sh "$REPO_DIR"/setup-helpers.mjs; do
+    [ -f "$file" ] && check_file "$file"
 done
 
 if [ "$VIOLATIONS" -gt 0 ]; then


### PR DESCRIPTION
## Summary
The pre-commit file length check missed:
- The `bin/` directory entirely (contains `bin/relaygent` at 195 lines)
- Extensionless scripts in `hooks/` (like `check-notifications`, `notification-poller`)

Now detects extensionless scripts by checking for a shebang (`#!`) in files without known extensions. Added `bin/` to the checked directories. Refactored to `check_file()` + `is_source_file()` helpers to reduce duplication.

## Test plan
- [ ] Run `bash scripts/check-file-length.sh 200` — should pass (all files ≤200)
- [ ] Run `bash scripts/check-file-length.sh 100` — should list `bin/relaygent` among violations
- [ ] Verify hooks/ extensionless scripts are also checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)