### PR TITLE
Fix stale one-off reminder accumulation

### DIFF
--- a/notifications/routes.py
+++ b/notifications/routes.py
@@ -54,13 +54,12 @@ def _collect_due_reminders(notifications):
                         "created_at": r["created_at"],
                     })
             elif r["trigger_time"] <= now_iso:
-                if r["trigger_time"] < stale_cutoff:
-                    conn.execute(
-                        "UPDATE reminders SET fired = 1 WHERE id = ?",
-                        (r["id"],),
-                    )
-                    conn.commit()
-                else:
+                conn.execute(
+                    "UPDATE reminders SET fired = 1 WHERE id = ?",
+                    (r["id"],),
+                )
+                conn.commit()
+                if r["trigger_time"] >= stale_cutoff:
                     notifications.append({
                         "type": "reminder",
                         "id": r["id"],


### PR DESCRIPTION
## Summary
- One-off reminders (including sleep timeouts) were returned on every notification poll until they aged past the 1-hour stale cutoff
- This caused accumulation during sleep/wake cycles — the VM Claude reported multiple stale "Sleep timeout" reminders piling up
- Fix: mark one-off reminders as fired immediately when due, but still include recent ones in the response so they're not silently lost

## What changed
- `notifications/routes.py`: Moved the `UPDATE fired=1` to execute for all due one-off reminders, not just stale ones. The stale cutoff now controls whether the notification is included in the response (not whether it's marked fired).

## Before/After
- **Before**: Due reminder → returned every poll for up to 1 hour → finally marked fired
- **After**: Due reminder → marked fired + returned once → done

## Test plan
- [ ] Create a one-off reminder, let it fire, verify it's returned once then gone
- [ ] Run multiple sleep/wake cycles, verify no accumulation in `SELECT * FROM reminders WHERE fired=0`
- [ ] Verify stale reminders (>1h old) are cleaned up silently without being returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)