### PR TITLE
Sanitize all HTML rendering with DOMPurify

### DIFF
--- a/hub/package.json
+++ b/hub/package.json
@@ -19,6 +19,7 @@
     "@modelcontextprotocol/sdk": "^1.25.0",
     "better-sqlite3": "^11.0.0",
     "gray-matter": "^4.0.3",
+    "isomorphic-dompurify": "^3.0.0-rc.2",
     "marked": "^15.0.0",
     "ws": "^8.19.0"
   },

--- a/hub/src/lib/kb.js
+++ b/hub/src/lib/kb.js
@@ -3,6 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
 import { marked } from 'marked';
+import { sanitizeHtml } from './sanitize.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_DIR = path.join(__dirname, '..', '..', '..');
@@ -88,7 +89,7 @@ export function getTopic(slug) {
 	} catch {
 		return { slug, title: slug, html: '<p>Error: could not parse this topic file.</p>', backlinks: [] };
 	}
-	const html = renderWikiLinks(marked(content));
+	const html = sanitizeHtml(renderWikiLinks(marked(content)));
 	const allFiles = findMarkdownFiles(KB_DIR).filter(({ slug: s }) => s !== slug);
 	const backlinks = allFiles.filter(({ filepath: fp }) => {
 		try {

--- a/hub/src/lib/sanitize.js
+++ b/hub/src/lib/sanitize.js
@@ -1,0 +1,7 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+/** Sanitize HTML to prevent XSS. Allows markdown-generated tags. */
+export function sanitizeHtml(html) {
+	if (!html) return '';
+	return DOMPurify.sanitize(html);
+}

--- a/hub/src/routes/+page.svelte
+++ b/hub/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import ContextBar from '$lib/components/ContextBar.svelte';
 	import ActivityFeed from '$lib/components/ActivityFeed.svelte';
 	import ScreenStream from '$lib/components/ScreenStream.svelte';
+	import { sanitizeHtml } from '$lib/sanitize.js';
 
 	let { data } = $props();
 	let screenOpen = $state(false);
@@ -110,7 +111,7 @@
 <section class="attention">
 	<div class="att-hdr"><h3>Attention</h3><button class="clear-all" onclick={clearAllAttention}>Clear</button></div>
 	{#each attentionItems as item, i}
-		<div class="att-item"><span>{@html item}</span><button class="x" onclick={() => clearAttentionItem(i)}>x</button></div>
+		<div class="att-item"><span>{@html sanitizeHtml(item)}</span><button class="x" onclick={() => clearAttentionItem(i)}>x</button></div>
 	{/each}
 </section>
 {/if}

--- a/hub/src/routes/forum/[id]/+page.svelte
+++ b/hub/src/routes/forum/[id]/+page.svelte
@@ -1,9 +1,10 @@
 <script>
 	import { marked } from 'marked';
+	import { sanitizeHtml } from '$lib/sanitize.js';
 	import { invalidateAll } from '$app/navigation';
 	let { data } = $props();
 	marked.setOptions({ breaks: true, gfm: true });
-	function renderMarkdown(text) { return text ? marked(text) : ''; }
+	function renderMarkdown(text) { return text ? sanitizeHtml(marked(text)) : ''; }
 	const categoryColors = { discussion: '#6b7280', proposal: '#8b5cf6', question: '#f59e0b', idea: '#10b981' };
 
 	let replyingTo = $state(null);

--- a/hub/src/routes/intent/+page.server.js
+++ b/hub/src/routes/intent/+page.server.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
 import { marked } from 'marked';
+import { sanitizeHtml } from '$lib/sanitize.js';
 
 const INTENT_PATH = path.join(getKbDir(), 'intent.md');
 
@@ -11,7 +12,7 @@ export function load() {
 	if (!fs.existsSync(INTENT_PATH)) throw error(404, 'Intent file not found');
 	const raw = fs.readFileSync(INTENT_PATH, 'utf-8');
 	const { data: frontmatter, content } = matter(raw);
-	const html = marked(content);
+	const html = sanitizeHtml(marked(content));
 	return {
 		title: frontmatter.title || 'Intent',
 		updated: frontmatter.updated || null,


### PR DESCRIPTION
## Summary
- Add `isomorphic-dompurify` dependency for DOM-based XSS sanitization
- Create centralized `sanitize.js` module wrapping DOMPurify
- Apply sanitization at all 5 `{@html}` rendering sites: homepage attention items, forum posts/comments, intent page, KB topic pages

Supersedes #22 — uses `isomorphic-dompurify` (industry-standard DOM-based sanitizer) instead of regex-based approach, per review feedback.

## Test plan
- [ ] Forum posts render markdown correctly (bold, links, code blocks)
- [ ] KB topic pages render with wiki-links intact
- [ ] Intent page renders markdown
- [ ] Verify XSS payloads are stripped: `<img onerror=alert(1)>`, `<a href="javascript:alert(1)">`
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)