### PR TITLE
Fix cmd modifier mapping and add a11y deps for Linux

### DIFF
--- a/computer-use/linux_input.py
+++ b/computer-use/linux_input.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 
 # xdotool modifier key mapping (macOS names -> X11 names)
-MOD_MAP = {"cmd": "super", "alt": "alt", "ctrl": "ctrl", "shift": "shift"}
+MOD_MAP = {"cmd": "ctrl", "alt": "alt", "ctrl": "ctrl", "shift": "shift"}
 
 # Key name mapping (macOS/Hammerspoon names -> xdotool names)
 KEY_MAP = {

--- a/setup-helpers.mjs
+++ b/setup-helpers.mjs
@@ -6,7 +6,7 @@ import { join } from 'path';
 export function setupHammerspoon(config, REPO_DIR, HOME, C, ask) {
 	if (process.platform !== 'darwin') {
 		console.log(`  Computer-use: ${C.yellow}Linux detected${C.reset} — uses python linux-server.py (started automatically)`);
-		console.log(`  ${C.dim}Debian/Ubuntu: sudo apt install xdotool scrot wmctrl imagemagick${C.reset}`);
+		console.log(`  ${C.dim}Debian/Ubuntu: sudo apt install xdotool scrot wmctrl imagemagick at-spi2-core python3-pyatspi gir1.2-atspi-2.0${C.reset}`);
 		return;
 	}
 	const hsDir = join(HOME, '.hammerspoon');


### PR DESCRIPTION
## Summary
- **cmd→ctrl fix**: The `MOD_MAP` in `linux_input.py` mapped `cmd` to `super` instead of `ctrl`. MCP tools use macOS naming (`cmd` for copy/paste), so on Linux `cmd` should translate to `ctrl` — Cmd+C should produce Ctrl+C, not Super+C.
- **Accessibility deps**: Added `at-spi2-core python3-pyatspi gir1.2-atspi-2.0` to the Linux setup hint in `setup-helpers.mjs`. Without these, `element_at`, `find_elements`, `accessibility_tree`, and `click_element` all fail.

Both issues found by the supervised relaygent Claude during testing.

## Test plan
- [ ] Verify `cmd` modifier key produces `ctrl` behavior on Linux (e.g., Cmd+C copies)
- [ ] Verify setup hint shows full apt install command including pyatspi packages
- [ ] Verify macOS behavior unchanged (macOS path uses Hammerspoon, not linux_input.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)