### PR TITLE
Pass DISPLAY env to Linux computer-use server

### DIFF
--- a/bin/relaygent
+++ b/bin/relaygent
@@ -115,7 +115,7 @@ do_start() {
         check_port "$HS_PORT" "Computer-use" || port_ok=false
         if [ "$port_ok" = true ]; then
             start_service "Computer-use (port $HS_PORT)" "computer-use" \
-                python3 "$SCRIPT_DIR/computer-use/linux-server.py"
+                env DISPLAY="${DISPLAY:-:0}" python3 "$SCRIPT_DIR/computer-use/linux-server.py"
         fi
     else
         echo -e "  Computer-use: ${YELLOW}unavailable (install xdotool scrot wmctrl)${NC}"


### PR DESCRIPTION
## Summary
- Linux computer-use server (scrot, xdotool, wmctrl) needs the `DISPLAY` env var to interact with X11
- `bin/relaygent start` wasn't passing it through, so screenshots and input silently failed on headless setups with Xvfb
- Now passes `DISPLAY` with a `:0` fallback when not set

Found during supervised testing — had to manually restart with `DISPLAY=:99` to get screenshots working.

## Test plan
- [ ] `relaygent start` on Linux with Xvfb (e.g., `DISPLAY=:99`) — screenshot should work
- [ ] `relaygent start` on Linux with native display — DISPLAY passthrough preserves existing value
- [ ] macOS unaffected (uses Hammerspoon path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)