### PR TITLE
Exit setup on Python venv failure

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -119,6 +119,9 @@ async function main() {
 			console.log(`  ${sub}: ${C.green}venv ready${C.reset}`);
 		} catch {
 			console.log(`  ${sub}: ${C.red}venv failed${C.reset}. Debian/Ubuntu: sudo apt install python3-venv`);
+			console.log(`  ${C.red}Cannot continue without ${sub}. Fix the error above and re-run setup.${C.reset}`);
+			rl.close();
+			process.exit(1);
 		}
 	}
 	console.log(`  Building hub...`);


### PR DESCRIPTION
## Summary
- When `python3 -m venv` fails during setup (common on Debian/Ubuntu without `python3-venv` package), the script printed an error but continued to completion
- This left forum and notifications services without their Python dependencies, causing confusing failures on first `relaygent start`
- Now exits immediately with a clear error message directing the user to fix the issue

## Test plan
- [ ] Run setup on a system without `python3-venv` — should exit with clear error instead of completing
- [ ] Run setup on a system with `python3-venv` — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)