### PR TITLE
Add crash backoff to notification-poller

### DIFF
--- a/hooks/check-notifications
+++ b/hooks/check-notifications
@@ -4,12 +4,23 @@
 
 CACHE_FILE="/tmp/relaygent-notifications-cache.json"
 
-# Ensure notification-poller is running
+# Ensure notification-poller is running (with crash backoff)
 POLLER_SCRIPT="$(dirname "$0")/notification-poller"
+POLLER_CRASH_FILE="/tmp/relaygent-poller-last-start"
 if ! pgrep -f "relaygent.*notification-poller" &>/dev/null; then
     if [[ -x "$POLLER_SCRIPT" ]]; then
-        nohup "$POLLER_SCRIPT" &>/dev/null &
-        disown
+        # Backoff: don't restart if last start was <10s ago (likely crash loop)
+        local_ok=true
+        if [[ -f "$POLLER_CRASH_FILE" ]]; then
+            last_start=$(cat "$POLLER_CRASH_FILE" 2>/dev/null || echo 0)
+            now=$(date +%s)
+            (( now - last_start < 10 )) && local_ok=false
+        fi
+        if [[ "$local_ok" = true ]]; then
+            date +%s > "$POLLER_CRASH_FILE"
+            nohup "$POLLER_SCRIPT" &>/dev/null &
+            disown
+        fi
     fi
 fi
 

--- a/hooks/notification-poller
+++ b/hooks/notification-poller
@@ -15,10 +15,11 @@ echo '[]' > "$CACHE_FILE"
 
 while true; do
     # Poll notifications (fast mode — DB only, skip slow checks)
-    RESULT=$(curl -s --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null)
-    if [[ -n "$RESULT" ]]; then
-        echo "$RESULT" > "${CACHE_FILE}.tmp" && mv "${CACHE_FILE}.tmp" "$CACHE_FILE"
+    if RESULT=$(curl -sf --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null); then
+        # Only update cache on successful HTTP response with valid JSON
+        if [[ -n "$RESULT" ]] && echo "$RESULT" | python3 -c "import sys,json;json.load(sys.stdin)" 2>/dev/null; then
+            echo "$RESULT" > "${CACHE_FILE}.tmp" && mv "${CACHE_FILE}.tmp" "$CACHE_FILE"
+        fi
     fi
-
     sleep "$POLL_INTERVAL"
 done


### PR DESCRIPTION
## Summary
- The `check-notifications` hook respawned the notification-poller on every tool call if it wasn't running, with no protection against crash loops
- If the notifications API was permanently down, this caused rapid restarts on every Claude tool use
- Added 10-second backoff between poller restarts using a timestamp file
- Also hardened the poller itself: `curl -f` to fail on HTTP errors, and JSON validation before updating the cache file

## Test plan
- [ ] Kill notification-poller manually → hook restarts it within one tool call
- [ ] Kill it again immediately (<10s) → hook does NOT restart it (backoff active)
- [ ] Wait 10s → hook restarts it again
- [ ] Stop notifications service → poller keeps running but cache retains last good data

🤖 Generated with [Claude Code](https://claude.com/claude-code)