### PR TITLE
Fix JSONL tail read to skip partial lines and handle UTF-8

### DIFF
--- a/harness/jsonl_checks.py
+++ b/harness/jsonl_checks.py
@@ -38,15 +38,19 @@ def get_jsonl_size(session_id: str, workspace: Path) -> int:
 
 
 def _read_tail(jsonl: Path, bytes_count: int = 65536) -> list[str]:
-    """Read last N bytes of a JSONL file and return lines."""
+    """Read last N bytes of a JSONL file and return complete lines."""
     try:
         with open(jsonl, 'rb') as f:
             f.seek(0, 2)
             size = f.tell()
             if size == 0:
                 return []
-            f.seek(max(0, size - bytes_count))
-            return f.read().decode('utf-8', errors='ignore').strip().split('\n')
+            offset = max(0, size - bytes_count)
+            f.seek(offset)
+            if offset > 0:
+                f.readline()  # Skip partial first line after seeking mid-file
+            data = f.read().decode('utf-8', errors='replace')
+            return [l for l in data.strip().split('\n') if l.strip()]
     except OSError:
         return []
 


### PR DESCRIPTION
## Summary
- `_read_tail()` seeks to a byte offset mid-file, but the first "line" at that position is always a partial fragment
- This partial line was passed to `json.loads()` which silently failed, potentially skipping valid data
- Now calls `f.readline()` after seeking to advance past the partial first line
- Changed `errors='ignore'` to `errors='replace'` — corrupted UTF-8 bytes now show as replacement characters instead of being silently dropped (which could cause subtle JSON key matching issues)

## Test plan
- [ ] Relay harness monitors context fill correctly during long sessions
- [ ] `should_sleep()` correctly detects text output even with large JSONL files (>64KB)
- [ ] `check_incomplete_exit()` correctly detects mid-conversation exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)