### PR TITLE
Harden reliability: partial failures, atomic writes, stdin guards

### DIFF
--- a/harness/process.py
+++ b/harness/process.py
@@ -129,10 +129,14 @@ class ClaudeProcess:
             self._close_log()
             raise
         try:
-            self.process.stdin.write(message.encode())
-            self.process.stdin.close()
-        except (BrokenPipeError, OSError):
-            log("WARNING: Could not write to Claude stdin (process may have exited)")
+            if self.process.stdin and not self.process.stdin.closed:
+                self.process.stdin.write(message.encode())
+                self.process.stdin.flush()
+                self.process.stdin.close()
+            else:
+                log("WARNING: stdin unavailable (process may have exited)")
+        except (BrokenPipeError, OSError) as e:
+            log(f"WARNING: Could not write to Claude stdin: {e}")
         return log_start
 
     def monitor(self, log_start: int) -> ClaudeResult:

--- a/hooks/check-notifications
+++ b/hooks/check-notifications
@@ -76,7 +76,7 @@ for line in reversed(data.strip().split(chr(10))):
     except: continue
 " 2>/dev/null)
     if [[ -n "$FILL_PCT" ]]; then
-        echo "$FILL_PCT" > "$CONTEXT_PCT_FILE"
+        echo "$FILL_PCT" > "${CONTEXT_PCT_FILE}.tmp" && mv "${CONTEXT_PCT_FILE}.tmp" "$CONTEXT_PCT_FILE"
         if [[ "$FILL_PCT" -ge "$CONTEXT_THRESHOLD" ]]; then
             CTX="$CTX | CONTEXT ${FILL_PCT}% — Wrap up: rewrite handoff.md, update working-state.md, commit KB, then stop."
         fi

--- a/notifications/routes.py
+++ b/notifications/routes.py
@@ -21,8 +21,14 @@ HUB_PORT = os.environ.get("RELAYGENT_HUB_PORT", "8080")
 def get_notifications():
     """Unified endpoint: return all pending notifications."""
     notifications = []
-    _collect_due_reminders(notifications)
-    _collect_chat_messages(notifications)
+    try:
+        _collect_due_reminders(notifications)
+    except Exception:
+        logger.exception("Failed to collect due reminders")
+    try:
+        _collect_chat_messages(notifications)
+    except Exception:
+        logger.exception("Failed to collect chat messages")
     return jsonify(notifications)
 
 


### PR DESCRIPTION
## Summary
- **notifications/routes.py**: Each notification collector wrapped in try/except — if reminders DB fails, chat messages still return (and vice versa)
- **hooks/check-notifications**: Atomic write to context-pct file via `tmp` + `mv` — prevents readers from seeing partial data during write
- **harness/process.py**: Guard stdin write with availability check + `flush()` before close, log specific error message

## Context
These are the remaining low-severity issues from the codebase audit (session 474). The 8 higher-severity issues were fixed in PRs #42-#48.

## Test plan
- [ ] Kill the hub while relay is running — notifications endpoint should still return reminders
- [ ] Verify context percentage still displays correctly on dashboard
- [ ] Resume a session — stdin message should be delivered cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)