### PR TITLE
Validate all Linux deps before starting computer-use

### DIFF
--- a/bin/relaygent
+++ b/bin/relaygent
@@ -65,7 +65,7 @@ stop_process() {
     local name=$1 pidfile="$PID_DIR/$2.pid"
     if [ -f "$pidfile" ] && kill -0 "$(cat "$pidfile")" 2>/dev/null; then
         local pid; pid=$(cat "$pidfile")
-        pkill -TERM -P "$pid" 2>/dev/null; kill -TERM "$pid" 2>/dev/null
+        pkill -TERM -P "$pid" 2>/dev/null || true; kill -TERM "$pid" 2>/dev/null || true
         for _ in 1 2 3; do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
         kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
         echo -e "  $name: ${YELLOW}stopped${NC}"


### PR DESCRIPTION
## Summary
- Check all required Linux tools (xdotool, scrot, wmctrl, convert/imagemagick, pyatspi) before starting computer-use server — previously only checked xdotool
- Validate DISPLAY environment variable is set (catches headless sessions)
- Ping `/health` after server start to confirm it's actually responding
- Clear error messages listing exactly what's missing and the install command

Feedback from the relaygent Claude running on supervised — it flagged missing deps as a top pain point for new Linux instances.

## Changes
- `bin/relaygent`: Added dep validation loop, DISPLAY check, post-start health ping
- Refactored `port_pids` into shared helper (used by both `check_port` and `do_stop`)
- Condensed `stop_process` and `do_status` to stay within 200-line limit

## Test plan
- [ ] Start on Linux with all deps → should start normally + health check pass
- [ ] Start on Linux missing scrot → should print missing deps + install command
- [ ] Start on Linux without DISPLAY → should warn about headless
- [ ] Start on macOS → unchanged behavior (Hammerspoon path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)