### PR TITLE
Add startup self-test for computer-use backend

### DIFF
--- a/computer-use/hammerspoon.mjs
+++ b/computer-use/hammerspoon.mjs
@@ -135,4 +135,16 @@ export async function clickElement({ title, role, app, index }) {
 	return { error: `No element found matching "${title || role}"` };
 }
 
+/** Startup self-test: verify backend is reachable. Logs warning to stderr. */
+export async function checkHealth() {
+	const r = await hsCallOnce("GET", "/health", null, 3000);
+	if (r.error) {
+		const backend = IS_LINUX ? "linux-server.py" : "Hammerspoon";
+		process.stderr.write(`[computer-use] Warning: ${backend} not reachable (${r.error})\n`);
+		return false;
+	}
+	process.stderr.write(`[computer-use] Backend OK (${r.platform || "macos"})\n`);
+	return true;
+}
+
 export { SCREENSHOT_PATH };

--- a/computer-use/mcp-server.mjs
+++ b/computer-use/mcp-server.mjs
@@ -7,7 +7,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { readFileSync } from "node:fs";
 import { platform } from "node:os";
-import { hsCall, takeScreenshot, runOsascript, findElements, clickElement, SCREENSHOT_PATH } from "./hammerspoon.mjs";
+import { hsCall, takeScreenshot, runOsascript, findElements, clickElement, checkHealth, SCREENSHOT_PATH } from "./hammerspoon.mjs";
 const IS_LINUX = platform() === "linux";
 
 const server = new McpServer({ name: "computer-use", version: "1.0.0" });
@@ -185,5 +185,6 @@ server.tool("applescript", "Run AppleScript via osascript.",
 server.tool("reload_config", "Reload Hammerspoon config", {},
 	async () => jsonRes(await hsCall("POST", "/reload")));
 
+await checkHealth();
 const transport = new StdioServerTransport();
 await server.connect(transport);


### PR DESCRIPTION
## Summary
- MCP server pings `/health` on the backend before accepting connections
- Logs clear warning to stderr if backend (Hammerspoon or linux-server.py) isn't reachable
- Catches startup failures immediately instead of on first tool invocation

From relaygent Claude feedback: "No startup self-test for computer-use — would catch missing deps early."

## Changes
- `computer-use/hammerspoon.mjs`: Added `checkHealth()` — calls `/health` with 3s timeout, logs result to stderr
- `computer-use/mcp-server.mjs`: Calls `checkHealth()` before connecting transport

## Test plan
- [ ] Start with backend running → should log "Backend OK (linux/macos)"
- [ ] Start with backend not running → should log warning with error details
- [ ] MCP tools still work normally after self-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)