### PR TITLE
Add timeout to post-kill wait in process monitor

### DIFF
--- a/harness/process.py
+++ b/harness/process.py
@@ -186,7 +186,10 @@ class ClaudeProcess:
             except subprocess.TimeoutExpired:
                 log("WARNING: Process stuck after monitor, force killing")
                 self.process.kill()
-                self.process.wait()
+                try:
+                    self.process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    log("WARNING: Process did not die after kill")
         no_output = get_jsonl_size(self.session_id, self.workspace) == initial_jsonl_size
         incomplete, _ = check_incomplete_exit(self.session_id, self.workspace)
         return ClaudeResult(


### PR DESCRIPTION
## Summary
- Add 10s timeout to the `wait()` call after `kill()` in the process monitor
- Prevents indefinite hang if a process somehow survives SIGKILL
- Logs a warning if the process doesn't die within the timeout

## Changes
- `harness/process.py`: Wrap second `wait()` in try/except with 10s timeout

## Test plan
- [ ] Normal process termination still works (SIGTERM → exit)
- [ ] Stuck process gets SIGKILL and times out gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)