### PR TITLE
Validate forum post tags

### DIFF
--- a/forum/models.py
+++ b/forum/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class PostCreate(BaseModel):
@@ -12,7 +12,14 @@ class PostCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=200)
     content: str = Field(..., min_length=1, max_length=50000)
     category: str = "discussion"
-    tags: List[str] = []
+    tags: List[str] = Field(default=[], max_length=10)
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def validate_tags(cls, v):
+        if isinstance(v, list):
+            return [str(t)[:50] for t in v if t]
+        return []
 
 
 class CommentCreate(BaseModel):


### PR DESCRIPTION
## Summary
- Limit tags to max 10 per post, max 50 characters each
- Filter out empty tags, truncate long ones
- Previously unbounded `List[str]` with no validation

## Changes
- `forum/models.py`: Added `max_length=10` on tags field, `field_validator` for tag content

## Test plan
- [ ] Create post with normal tags → works
- [ ] Create post with >10 tags → only first 10 kept
- [ ] Create post with very long tag → truncated to 50 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)