### PR TITLE
Harden email + secrets with atomic writes

### DIFF
--- a/secrets/mcp-server.mjs
+++ b/secrets/mcp-server.mjs
@@ -10,7 +10,9 @@ import { getSecret, setSecret, listSecrets, deleteSecret, vaultExists } from "./
 
 const password = process.env.RELAYGENT_MASTER_PASSWORD;
 if (!password) {
-	process.stderr.write("[secrets] ERROR: RELAYGENT_MASTER_PASSWORD not set\n");
+	process.stderr.write("[secrets] ERROR: RELAYGENT_MASTER_PASSWORD not set.\n");
+	process.stderr.write("[secrets] Start with: relaygent start (prompts for password)\n");
+	process.stderr.write("[secrets] Or set: export RELAYGENT_MASTER_PASSWORD=<your-password>\n");
 	process.exit(1);
 }
 

--- a/secrets/vault.mjs
+++ b/secrets/vault.mjs
@@ -3,7 +3,7 @@
  * Stores secrets in ~/.relaygent/secrets.enc as encrypted JSON.
  */
 import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from "crypto";
-import { readFileSync, writeFileSync, existsSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, renameSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -45,10 +45,16 @@ export function vaultExists() {
 	return existsSync(VAULT_PATH);
 }
 
+function atomicWrite(path, data) {
+	const tmp = path + ".tmp";
+	writeFileSync(tmp, data);
+	renameSync(tmp, path);
+}
+
 export function createVault(masterPassword) {
 	const secrets = {};
 	const data = encrypt(JSON.stringify(secrets), masterPassword);
-	writeFileSync(VAULT_PATH, data);
+	atomicWrite(VAULT_PATH, data);
 }
 
 export function loadVault(masterPassword) {
@@ -63,7 +69,7 @@ export function loadVault(masterPassword) {
 
 function saveVault(secrets, masterPassword) {
 	const data = encrypt(JSON.stringify(secrets), masterPassword);
-	writeFileSync(VAULT_PATH, data);
+	atomicWrite(VAULT_PATH, data);
 }
 
 export function getSecret(masterPassword, name) {


### PR DESCRIPTION
## Summary
- **vault.mjs**: Use atomic writes (write to `.tmp` then `rename`) to prevent vault corruption if process crashes mid-write. A partial `writeFileSync` would leave an unreadable vault — atomic rename is all-or-nothing.
- **gmail-client.mjs**: Same atomic write pattern for OAuth token persistence. Added try/catch on token refresh callback so a write failure doesn't crash the MCP server.
- **secrets/mcp-server.mjs**: Better error message when `RELAYGENT_MASTER_PASSWORD` not set — now explains how to fix it (`relaygent start` or `export`).

## Why
The vault and OAuth tokens are the agent's most critical persistent state. A power loss or crash during `writeFileSync` could corrupt them permanently. Atomic rename ensures the file is either the old version or the new version, never a partial write.

## Test plan
- [ ] Pre-commit passes
- [ ] `node -e "import('./secrets/vault.mjs')"` — no syntax errors
- [ ] `node -e "import('./email/gmail-client.mjs')"` — no syntax errors (will fail on missing googleapis, that's expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)