### PR TITLE
Fix browser_navigate for Linux + app launch aliases

### DIFF
--- a/computer-use/linux_display.py
+++ b/computer-use/linux_display.py
@@ -129,12 +129,21 @@ def focus(params: dict) -> tuple[dict, int]:
     return {"error": "not found"}, 404
 
 
+# Common Linux aliases for apps that have different binary names
+_ALIASES = {
+    "google-chrome": ["google-chrome-stable", "chromium-browser", "chromium", "firefox"],
+    "firefox": ["firefox-esr"],
+}
+
+
 def launch(params: dict) -> tuple[dict, int]:
     app = params.get("app")
     if not app:
         return {"error": "app required"}, 400
-    # Try original name, lowercase, and hyphenated-lowercase
+    # Try original name, lowercase, hyphenated-lowercase, then aliases
     candidates = [app, app.lower(), app.lower().replace(" ", "-")]
+    base = app.lower().replace(" ", "-")
+    candidates.extend(_ALIASES.get(base, []))
     for name in dict.fromkeys(candidates):  # dedup preserving order
         try:
             subprocess.Popen([name], stdout=subprocess.DEVNULL,

--- a/computer-use/mcp-server.mjs
+++ b/computer-use/mcp-server.mjs
@@ -152,12 +152,13 @@ server.tool("click_element", "Find UI element by title/role and click it. Auto-r
 	}
 );
 
-server.tool("browser_navigate", "Navigate Chrome to a URL. Auto-returns screenshot.",
+server.tool("browser_navigate", "Navigate browser to a URL. Auto-returns screenshot.",
 	{ url: z.string().describe("URL to navigate to"),
 		new_tab: z.boolean().optional().describe("Open in new tab") },
 	async ({ url, new_tab }) => {
 		const mod = IS_LINUX ? "ctrl" : "cmd";
-		await hsCall("POST", "/launch", { app: "Google Chrome" });
+		const browser = IS_LINUX ? "google-chrome" : "Google Chrome";
+		await hsCall("POST", "/launch", { app: browser });
 		await new Promise(r => setTimeout(r, 300));
 		await hsCall("POST", "/type", { key: new_tab ? "t" : "l", modifiers: [mod] });
 		await new Promise(r => setTimeout(r, 200));


### PR DESCRIPTION
## Summary
- **mcp-server.mjs**: `browser_navigate` used `"Google Chrome"` (macOS app name) on all platforms. On Linux, the binary is typically `google-chrome`, `google-chrome-stable`, or `chromium`. Now uses `"google-chrome"` on Linux.
- **linux_display.py**: Added alias fallback chain for `launch()`. When `google-chrome` isn't found, tries `google-chrome-stable` → `chromium-browser` → `chromium` → `firefox`. Same for `firefox` → `firefox-esr`.

## Why
`browser_navigate` was broken on most Linux installs because the Chrome binary name differs between macOS and Linux. This was a silent failure — the launch would 404 and then keystrokes would go to whatever window was focused.

## Test plan
- [ ] Pre-commit passes
- [ ] On macOS: `browser_navigate` still uses "Google Chrome" (unchanged behavior)
- [ ] On Linux: `browser_navigate` resolves to an installed browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)