### PR TITLE
Add /api/health endpoint to hub server

### DIFF
--- a/hub/server.js
+++ b/hub/server.js
@@ -5,7 +5,14 @@ import fs from 'fs';
 import path from 'path';
 import { summarizeInput, summarizeResult, extractResultText, findLatestSession } from './src/lib/relayActivity.js';
 
-const server = createServer(handler);
+const server = createServer((req, res) => {
+	if (req.url === '/api/health') {
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end('{"status":"ok"}');
+		return;
+	}
+	handler(req, res);
+});
 
 // Two WebSocket endpoints: relay activity + chat
 const relayWss = new WebSocketServer({ noServer: true });


### PR DESCRIPTION
## Summary
- Added `/api/health` endpoint to the hub Node.js server, intercepted before the SvelteKit handler
- Returns `{"status":"ok"}` with 200 status code

## Why
`orient.sh` checks `http://localhost:PORT/api/health` to determine if the hub is running, but this endpoint didn't exist — the SvelteKit handler returned 404. This meant orient.sh **always reported the hub as "down"** even when it was running fine. Every new relay session started thinking the hub was broken.

## Test plan
- [ ] `curl http://localhost:8080/api/health` returns `{"status":"ok"}`
- [ ] `relaygent orient` shows Hub as "running" (not "down")
- [ ] All other hub routes still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)