### PR TITLE
Add test suite for harness (52 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 __pycache__/
 *.pyc
 .venv/
+.test-venv/
+.pytest_cache/
 *.pid
 package-lock.json
 harness/settings.json

--- a/harness/test_config.py
+++ b/harness/test_config.py
@@ -1,0 +1,79 @@
+"""Tests for configuration and Timer."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import Timer, cleanup_old_workspaces, get_workspace_dir
+
+
+class TestTimer:
+    def test_elapsed_increases(self):
+        t = Timer()
+        time.sleep(0.05)
+        assert t.elapsed() >= 0
+
+    def test_never_expires(self):
+        t = Timer()
+        assert t.is_expired() is False
+
+    def test_remaining_is_large(self):
+        t = Timer()
+        assert t.remaining() > 9000
+
+    def test_always_has_successor_time(self):
+        t = Timer()
+        assert t.has_successor_time() is True
+
+
+class TestGetWorkspaceDir:
+    def test_creates_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.RUNS_DIR", tmp_path / "runs")
+        ws = get_workspace_dir()
+        assert ws.exists()
+        assert ws.is_dir()
+        assert ws.parent == tmp_path / "runs"
+
+    def test_unique_names(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.RUNS_DIR", tmp_path / "runs")
+        ws1 = get_workspace_dir()
+        # Tiny delay to get different timestamp
+        time.sleep(1.1)
+        ws2 = get_workspace_dir()
+        assert ws1 != ws2
+
+
+class TestCleanupOldWorkspaces:
+    def test_removes_old_directories(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.RUNS_DIR", tmp_path)
+        old_dir = tmp_path / "2020-01-01-00-00-00"
+        old_dir.mkdir()
+        # Set mtime to 30 days ago
+        old_time = time.time() - (30 * 86400)
+        import os
+        os.utime(old_dir, (old_time, old_time))
+
+        new_dir = tmp_path / "2026-02-16-12-00-00"
+        new_dir.mkdir()
+
+        cleanup_old_workspaces(days=7)
+        assert not old_dir.exists()
+        assert new_dir.exists()
+
+    def test_keeps_recent_directories(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.RUNS_DIR", tmp_path)
+        recent = tmp_path / "recent-run"
+        recent.mkdir()
+
+        cleanup_old_workspaces(days=7)
+        assert recent.exists()
+
+    def test_handles_missing_runs_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("config.RUNS_DIR", tmp_path / "nonexistent")
+        # Should not raise
+        cleanup_old_workspaces(days=7)

--- a/harness/test_context_fill.py
+++ b/harness/test_context_fill.py
@@ -1,0 +1,113 @@
+"""Tests for context fill calculation from JSONL session files."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from jsonl_checks import get_context_fill_from_jsonl
+
+
+@pytest.fixture
+def tmp_jsonl(tmp_path):
+    """Helper to create a fake JSONL session file in the expected location."""
+    session_id = "test-session-abc"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    slug = str(workspace).replace("/", "-")
+    project_dir = tmp_path / ".claude" / "projects" / slug
+    project_dir.mkdir(parents=True)
+    jsonl_path = project_dir / f"{session_id}.jsonl"
+
+    def write_entries(entries: list[dict]):
+        jsonl_path.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n"
+        )
+
+    with patch("jsonl_checks.Path.home", return_value=tmp_path):
+        yield session_id, workspace, jsonl_path, write_entries
+
+
+class TestGetContextFill:
+    def test_calculates_fill_percentage(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "hi"}],
+                "usage": {
+                    "input_tokens": 100000, "output_tokens": 50000,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            }},
+        ])
+        fill = get_context_fill_from_jsonl(sid, ws)
+        assert fill == 75.0  # 150000 / 200000 * 100
+
+    def test_includes_cache_tokens(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "hi"}],
+                "usage": {
+                    "input_tokens": 50000, "output_tokens": 50000,
+                    "cache_creation_input_tokens": 30000,
+                    "cache_read_input_tokens": 20000,
+                },
+            }},
+        ])
+        fill = get_context_fill_from_jsonl(sid, ws)
+        assert fill == 75.0  # 150000 / 200000 * 100
+
+    def test_returns_zero_for_missing_file(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        assert get_context_fill_from_jsonl("no-session", ws) == 0.0
+
+    def test_returns_zero_for_no_usage_data(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "hi"}],
+            }},
+        ])
+        assert get_context_fill_from_jsonl(sid, ws) == 0.0
+
+    def test_uses_last_assistant_message(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "first"}],
+                "usage": {"input_tokens": 10000, "output_tokens": 10000,
+                          "cache_creation_input_tokens": 0,
+                          "cache_read_input_tokens": 0},
+            }},
+            {"type": "user", "message": {"content": "next"}},
+            {"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "second"}],
+                "usage": {"input_tokens": 160000, "output_tokens": 10000,
+                          "cache_creation_input_tokens": 0,
+                          "cache_read_input_tokens": 0},
+            }},
+        ])
+        fill = get_context_fill_from_jsonl(sid, ws)
+        assert fill == 85.0  # 170000 / 200000 * 100
+
+    def test_skips_malformed_lines(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        path.write_text(
+            json.dumps({"type": "assistant", "message": {
+                "content": [{"type": "text", "text": "hi"}],
+                "usage": {"input_tokens": 100000, "output_tokens": 0,
+                          "cache_creation_input_tokens": 0,
+                          "cache_read_input_tokens": 0},
+            }}) + "\n"
+            + "THIS IS NOT JSON\n"
+        )
+        fill = get_context_fill_from_jsonl(sid, ws)
+        assert fill == 50.0  # Skips bad line, finds valid one

--- a/harness/test_jsonl_checks.py
+++ b/harness/test_jsonl_checks.py
@@ -1,0 +1,194 @@
+"""Tests for JSONL session file inspection utilities."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Allow imports from harness directory
+sys.path.insert(0, str(Path(__file__).parent))
+
+from jsonl_checks import (
+    _read_tail,
+    check_incomplete_exit,
+    get_jsonl_size,
+    should_sleep,
+)
+
+
+@pytest.fixture
+def tmp_jsonl(tmp_path):
+    """Helper to create a fake JSONL session file in the expected location."""
+    session_id = "test-session-abc"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    slug = str(workspace).replace("/", "-")
+    project_dir = tmp_path / ".claude" / "projects" / slug
+    project_dir.mkdir(parents=True)
+    jsonl_path = project_dir / f"{session_id}.jsonl"
+
+    def write_entries(entries: list[dict]):
+        jsonl_path.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n"
+        )
+
+    with patch("jsonl_checks.Path.home", return_value=tmp_path):
+        yield session_id, workspace, jsonl_path, write_entries
+
+
+# --- _read_tail ---
+
+
+class TestReadTail:
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / "empty.jsonl"
+        f.write_text("")
+        assert _read_tail(f) == []
+
+    def test_single_line(self, tmp_path):
+        f = tmp_path / "one.jsonl"
+        f.write_text('{"type": "assistant"}\n')
+        lines = _read_tail(f)
+        assert len(lines) == 1
+        assert json.loads(lines[0])["type"] == "assistant"
+
+    def test_skips_partial_first_line_on_seek(self, tmp_path):
+        f = tmp_path / "big.jsonl"
+        # Write enough data that seeking skips the first line
+        lines = [json.dumps({"i": i, "pad": "x" * 100}) for i in range(1000)]
+        f.write_text("\n".join(lines) + "\n")
+        result = _read_tail(f, bytes_count=512)
+        # All returned lines should be valid JSON
+        for line in result:
+            parsed = json.loads(line)
+            assert "i" in parsed
+
+    def test_handles_utf8_gracefully(self, tmp_path):
+        f = tmp_path / "utf8.jsonl"
+        f.write_text('{"text": "héllo wörld 日本語"}\n')
+        lines = _read_tail(f)
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert "héllo" in parsed["text"]
+
+    def test_nonexistent_file(self, tmp_path):
+        f = tmp_path / "missing.jsonl"
+        assert _read_tail(f) == []
+
+
+# --- get_jsonl_size ---
+
+
+class TestGetJsonlSize:
+    def test_returns_size(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([{"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}])
+        size = get_jsonl_size(sid, ws)
+        assert size > 0
+        assert size == path.stat().st_size
+
+    def test_missing_session(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        assert get_jsonl_size("nonexistent-id", ws) == 0
+
+
+# --- check_incomplete_exit ---
+
+
+class TestCheckIncompleteExit:
+    def test_clean_exit_assistant_last(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Done."}]}},
+        ])
+        incomplete, tool = check_incomplete_exit(sid, ws)
+        assert not incomplete
+        assert tool == ""
+
+    def test_incomplete_tool_result_pending(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "tu_abc123"}
+            ]}},
+        ])
+        incomplete, tool = check_incomplete_exit(sid, ws)
+        assert incomplete
+        assert tool == "tu_abc123"
+
+    def test_incomplete_user_message_no_tool(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "user", "message": {"content": "just text"}},
+        ])
+        incomplete, tool = check_incomplete_exit(sid, ws)
+        assert incomplete
+        assert tool == ""
+
+    def test_no_jsonl_file(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        incomplete, tool = check_incomplete_exit("no-such-session", ws)
+        assert not incomplete
+
+    def test_empty_file(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        path.write_text("")
+        incomplete, tool = check_incomplete_exit(sid, ws)
+        assert not incomplete
+
+    def test_malformed_json(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        path.write_text("not valid json\n")
+        incomplete, tool = check_incomplete_exit(sid, ws)
+        assert not incomplete  # Gracefully handles parse errors
+
+
+# --- should_sleep ---
+
+
+class TestShouldSleep:
+    def test_sleeps_after_text_output(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "All done, going to sleep."}
+            ]}},
+        ])
+        assert should_sleep(sid, ws) is True
+
+    def test_no_sleep_if_last_is_tool_result(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "tu_xyz"}
+            ]}},
+        ])
+        assert should_sleep(sid, ws) is False
+
+    def test_no_sleep_if_only_tool_use(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": "tu_1", "name": "Read", "input": {}}
+            ]}},
+        ])
+        assert should_sleep(sid, ws) is False
+
+    def test_no_sleep_if_no_file(self, tmp_jsonl):
+        sid, ws, path, write = tmp_jsonl
+        assert should_sleep("missing-session", ws) is False
+
+    def test_sleeps_with_mixed_content(self, tmp_jsonl):
+        """If last assistant has both tool_use and text, should sleep."""
+        sid, ws, path, write = tmp_jsonl
+        write([
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {}},
+                {"type": "text", "text": "Done with that task."},
+            ]}},
+        ])
+        assert should_sleep(sid, ws) is True

--- a/harness/test_notify_format.py
+++ b/harness/test_notify_format.py
@@ -1,0 +1,99 @@
+"""Tests for notification formatting."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from notify_format import format_chat, format_notifications, format_reminders, format_unknown
+
+
+class TestFormatChat:
+    def test_formats_message_content(self):
+        notifs = [{"messages": [{"content": "Hello from Preston"}]}]
+        result = format_chat(notifs)
+        assert result == ["Hello from Preston"]
+
+    def test_multiple_messages(self):
+        notifs = [{"messages": [
+            {"content": "Line 1"},
+            {"content": "Line 2"},
+        ]}]
+        result = format_chat(notifs)
+        assert result == ["Line 1\nLine 2"]
+
+    def test_empty_messages(self):
+        notifs = [{"messages": []}]
+        result = format_chat(notifs)
+        assert "check unread" in result[0].lower()
+
+    def test_missing_messages_key(self):
+        notifs = [{}]
+        result = format_chat(notifs)
+        assert "check unread" in result[0].lower()
+
+
+class TestFormatReminders:
+    def test_formats_reminder(self):
+        notifs = [{"id": 42, "message": "Check the build"}]
+        result = format_reminders(notifs)
+        assert len(result) == 1
+        assert "42" in result[0]
+        assert "Check the build" in result[0]
+
+    def test_missing_fields(self):
+        notifs = [{}]
+        result = format_reminders(notifs)
+        assert "?" in result[0]
+        assert "no message" in result[0]
+
+
+class TestFormatUnknown:
+    def test_formats_unknown_type(self):
+        notifs = [{"type": "email", "message": "New email from Alice"}]
+        result = format_unknown(notifs)
+        assert "[email]" in result[0]
+        assert "Alice" in result[0]
+
+    def test_fallback_to_content(self):
+        notifs = [{"type": "sms", "content": "Hey there"}]
+        result = format_unknown(notifs)
+        assert "Hey there" in result[0]
+
+    def test_fallback_to_str(self):
+        notifs = [{"type": "weird"}]
+        result = format_unknown(notifs)
+        assert "weird" in result[0]
+
+
+class TestFormatNotifications:
+    def test_single_chat(self):
+        notifs = [{"type": "message", "messages": [{"content": "Hi"}]}]
+        result = format_notifications(notifs)
+        assert "Hi" in result
+
+    def test_single_reminder(self):
+        notifs = [{"type": "reminder", "id": 1, "message": "Do the thing"}]
+        result = format_notifications(notifs)
+        assert "Do the thing" in result
+
+    def test_mixed_types(self):
+        notifs = [
+            {"type": "message", "messages": [{"content": "Hello"}]},
+            {"type": "reminder", "id": 5, "message": "Check PR"},
+        ]
+        result = format_notifications(notifs)
+        assert "Hello" in result
+        assert "Check PR" in result
+        assert "---" in result  # Separator between types
+
+    def test_empty_notifications(self):
+        result = format_notifications([])
+        assert result == ""
+
+    def test_unknown_type_uses_fallback(self):
+        notifs = [{"type": "signal", "message": "New signal msg"}]
+        result = format_notifications(notifs)
+        assert "[signal]" in result

--- a/harness/test_relay_utils.py
+++ b/harness/test_relay_utils.py
@@ -1,0 +1,70 @@
+"""Tests for relay utility functions."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from relay_utils import cleanup_context_file, rotate_log
+
+
+class TestRotateLog:
+    def test_rotates_oversized_log(self, tmp_path, monkeypatch):
+        log_file = tmp_path / "test.log"
+        monkeypatch.setattr("relay_utils.LOG_FILE", log_file)
+        monkeypatch.setattr("relay_utils.LOG_MAX_SIZE", 100)
+        monkeypatch.setattr("relay_utils.LOG_TRUNCATE_SIZE", 50)
+
+        # Write 200 bytes of log lines
+        lines = [f"[2026-02-16] Log line {i:03d}\n" for i in range(10)]
+        log_file.write_text("".join(lines))
+        original_size = log_file.stat().st_size
+        assert original_size > 100
+
+        rotate_log()
+        new_size = log_file.stat().st_size
+        assert new_size < original_size
+        assert new_size <= 50
+
+        # Content should start at a complete line
+        content = log_file.read_text()
+        assert not content.startswith("\n")
+        assert content.endswith("\n")
+
+    def test_no_rotation_for_small_log(self, tmp_path, monkeypatch):
+        log_file = tmp_path / "small.log"
+        monkeypatch.setattr("relay_utils.LOG_FILE", log_file)
+        monkeypatch.setattr("relay_utils.LOG_MAX_SIZE", 10000)
+
+        log_file.write_text("Small log\n")
+        original = log_file.read_text()
+
+        rotate_log()
+        assert log_file.read_text() == original
+
+    def test_no_error_for_missing_log(self, tmp_path, monkeypatch):
+        log_file = tmp_path / "missing.log"
+        monkeypatch.setattr("relay_utils.LOG_FILE", log_file)
+        # Should not raise
+        rotate_log()
+
+
+class TestCleanupContextFile:
+    def test_removes_context_file(self, tmp_path):
+        pct_file = tmp_path / "relaygent-context-pct"
+        pct_file.write_text("85.3")
+
+        with patch("relay_utils.Path", return_value=pct_file):
+            cleanup_context_file()
+        assert not pct_file.exists()
+
+    def test_no_error_if_missing(self, tmp_path):
+        pct_file = tmp_path / "nonexistent"
+        with patch("relay_utils.Path", return_value=pct_file):
+            cleanup_context_file()  # Should not raise


### PR DESCRIPTION
## Summary
- **52 unit tests** across 5 test files covering all harness Python modules
- Tests for JSONL parsing (`_read_tail`, `get_jsonl_size`, `check_incomplete_exit`, `should_sleep`, `get_context_fill_from_jsonl`)
- Tests for notification formatting (chat, reminders, unknown types, mixed notifications)
- Tests for config (Timer, workspace creation/cleanup)
- Tests for relay utils (log rotation, context file cleanup)
- All tests use `tmp_path` fixtures — no external deps, no network, fast (~1.5s)
- Added `.test-venv/` and `.pytest_cache/` to `.gitignore`

## Running tests
```bash
python3 -m venv .test-venv && .test-venv/bin/pip install pytest
.test-venv/bin/python3 -m pytest harness/test_*.py -v
```

## Test plan
- [x] All 52 tests pass
- [x] All test files under 200 lines
- [x] No external dependencies beyond pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)