### PR TITLE
Add Slack MCP server

### DIFF
--- a/setup-helpers.mjs
+++ b/setup-helpers.mjs
@@ -129,8 +129,12 @@ export function setupHooks(config, REPO_DIR, HOME, C) {
 		command: 'node',
 		args: [join(REPO_DIR, 'email', 'mcp-server.mjs')],
 	};
+	claudeConfig.mcpServers['slack'] = {
+		command: 'node',
+		args: [join(REPO_DIR, 'slack', 'mcp-server.mjs')],
+	};
 	writeFileSync(claudeJson, JSON.stringify(claudeConfig, null, 2));
-	console.log(`  MCP: hub-chat + notifications + computer-use + secrets + email registered`);
+	console.log(`  MCP: hub-chat + notifications + computer-use + secrets + email + slack registered`);
 }
 
 export function envFromConfig(config) {

--- a/setup.mjs
+++ b/setup.mjs
@@ -122,7 +122,7 @@ async function main() {
 	} catch { /* not a git repo yet, skip */ }
 
 	// Install Node.js dependencies
-	for (const sub of ['hub', 'notifications', 'computer-use', 'email']) {
+	for (const sub of ['hub', 'notifications', 'computer-use', 'email', 'slack']) {
 		console.log(`  Installing ${sub} dependencies...`);
 		execSync('npm install', { cwd: join(REPO_DIR, sub), stdio: 'pipe' });
 		console.log(`  ${sub}: ${C.green}deps installed${C.reset}`);

--- a/slack/mcp-server.mjs
+++ b/slack/mcp-server.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Slack MCP server — send messages, read channels, check unread, react.
+ * Token from ~/.relaygent/slack/token.json (user OAuth xoxp-).
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { slack } from "./slack-client.mjs";
+
+const server = new McpServer({ name: "slack", version: "1.0.0" });
+const txt = (t) => ({ content: [{ type: "text", text: t }] });
+
+server.tool("slack_send",
+	"Send a Slack message to a channel or user. Pass a user ID (U...) or channel ID (C.../D...).",
+	{ channel: z.string().describe("Channel ID, DM ID, or user ID (U... opens DM automatically)"),
+	  text: z.string().describe("Message text (supports Slack markdown)") },
+	async ({ channel, text: msg }) => {
+		try {
+			const res = await slack("chat.postMessage", { channel, text: msg });
+			return txt(`Sent to ${res.channel} (ts: ${res.ts})`);
+		} catch (e) { return txt(`Slack send error: ${e.message}`); }
+	}
+);
+
+server.tool("slack_read",
+	"Read recent messages from a Slack channel or DM.",
+	{ channel: z.string().describe("Channel or DM ID"),
+	  limit: z.number().default(20).describe("Number of messages (max 100)") },
+	async ({ channel, limit }) => {
+		try {
+			const res = await slack("conversations.history", {
+				channel, limit: Math.min(limit, 100),
+			});
+			if (!res.messages?.length) return txt("No messages.");
+			const lines = res.messages.reverse().map(m => {
+				const ts = new Date(parseFloat(m.ts) * 1000).toLocaleTimeString();
+				const who = m.user || m.bot_id || "unknown";
+				return `[${ts}] ${who}: ${m.text}`;
+			});
+			return txt(lines.join("\n"));
+		} catch (e) { return txt(`Slack read error: ${e.message}`); }
+	}
+);
+
+server.tool("slack_unread",
+	"Check for unread Slack DMs and group DMs.",
+	{},
+	async () => {
+		try {
+			const res = await slack("conversations.list", {
+				types: "im,mpim", exclude_archived: true, limit: 50,
+			});
+			const unread = (res.channels || []).filter(c =>
+				(c.unread_count_display || 0) > 0
+			);
+			if (!unread.length) return txt("No unread Slack DMs.");
+			const lines = [];
+			for (const ch of unread) {
+				const hist = await slack("conversations.history", {
+					channel: ch.id, limit: ch.unread_count_display,
+				});
+				const msgs = (hist.messages || []).reverse();
+				for (const m of msgs) {
+					const ts = new Date(parseFloat(m.ts) * 1000).toLocaleTimeString();
+					lines.push(`[${ch.id}] [${ts}] ${m.user || "bot"}: ${m.text}`);
+				}
+			}
+			return txt(`${unread.length} channel(s) with unread:\n${lines.join("\n")}`);
+		} catch (e) { return txt(`Slack unread error: ${e.message}`); }
+	}
+);
+
+server.tool("slack_channels",
+	"List Slack channels the user is a member of.",
+	{ types: z.string().default("public_channel,private_channel,im,mpim")
+		.describe("Channel types to list") },
+	async ({ types }) => {
+		try {
+			const res = await slack("conversations.list", {
+				types, exclude_archived: true, limit: 100,
+			});
+			const lines = (res.channels || []).map(c => {
+				const name = c.name || c.user || c.id;
+				const unread = c.unread_count_display ? ` (${c.unread_count_display} unread)` : "";
+				return `${c.id}: ${name}${unread}`;
+			});
+			return txt(lines.join("\n") || "No channels found.");
+		} catch (e) { return txt(`Slack channels error: ${e.message}`); }
+	}
+);
+
+server.tool("slack_users",
+	"List users in the Slack workspace.",
+	{},
+	async () => {
+		try {
+			const res = await slack("users.list", {});
+			const users = (res.members || []).filter(u => !u.deleted && !u.is_bot);
+			const lines = users.map(u =>
+				`${u.id}: ${u.real_name || u.name} (@${u.name})`
+			);
+			return txt(lines.join("\n") || "No users found.");
+		} catch (e) { return txt(`Slack users error: ${e.message}`); }
+	}
+);
+
+server.tool("slack_react",
+	"Add an emoji reaction to a message.",
+	{ channel: z.string().describe("Channel ID"),
+	  timestamp: z.string().describe("Message timestamp (ts)"),
+	  emoji: z.string().describe("Emoji name without colons (e.g. thumbsup)") },
+	async ({ channel, timestamp, emoji }) => {
+		try {
+			await slack("reactions.add", { channel, timestamp, name: emoji });
+			return txt(`Reacted with :${emoji}:`);
+		} catch (e) { return txt(`Slack react error: ${e.message}`); }
+	}
+);
+
+server.tool("slack_search",
+	"Search Slack messages.",
+	{ query: z.string().describe("Search query"),
+	  count: z.number().default(10).describe("Number of results") },
+	async ({ query, count }) => {
+		try {
+			const res = await slack("search.messages", { query, count });
+			const matches = res.messages?.matches || [];
+			if (!matches.length) return txt("No results.");
+			const lines = matches.map(m => {
+				const ts = new Date(parseFloat(m.ts) * 1000).toLocaleString();
+				return `[${ts}] ${m.username}: ${m.text}\n  Channel: ${m.channel?.name || m.channel?.id}`;
+			});
+			return txt(lines.join("\n\n"));
+		} catch (e) { return txt(`Slack search error: ${e.message}`); }
+	}
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/slack/package.json
+++ b/slack/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "relaygent-slack",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "zod": "^4.3.6"
+  }
+}

--- a/slack/slack-client.mjs
+++ b/slack/slack-client.mjs
@@ -1,0 +1,31 @@
+/**
+ * Slack Web API client. Reads token from ~/.relaygent/slack/token.json.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+let _token = null;
+
+export function getToken() {
+	if (_token) return _token;
+	const tokenPath = join(homedir(), ".relaygent", "slack", "token.json");
+	const data = JSON.parse(readFileSync(tokenPath, "utf-8"));
+	_token = data.access_token;
+	return _token;
+}
+
+export async function slack(method, params = {}) {
+	const token = getToken();
+	const res = await fetch(`https://slack.com/api/${method}`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json; charset=utf-8",
+		},
+		body: JSON.stringify(params),
+	});
+	const data = await res.json();
+	if (!data.ok) throw new Error(`Slack ${method}: ${data.error}`);
+	return data;
+}


### PR DESCRIPTION
## Summary
- New `slack/mcp-server.mjs` with 7 tools: `slack_send`, `slack_read`, `slack_unread`, `slack_channels`, `slack_users`, `slack_react`, `slack_search`
- New `slack/slack-client.mjs` — thin wrapper around Slack Web API, reads token from `~/.relaygent/slack/token.json`
- Added `slack` to npm install loop in `setup.mjs`
- Added Slack MCP registration in `setup-helpers.mjs`

## Details
Token is a user OAuth token (xoxp-) stored at `~/.relaygent/slack/token.json`. The MCP server uses the Slack Web API directly (chat.postMessage, conversations.history, conversations.list, users.list, reactions.add, search.messages).

Tested on unsupervised — sending messages, listing channels, and checking unread all work.

## Test plan
- [ ] Verify `npm install` works in `slack/` directory
- [ ] Test `slack_send` to a known user/channel
- [ ] Test `slack_read` on a DM channel
- [ ] Test `slack_unread` returns correct unread counts
- [ ] Verify setup.mjs installs slack deps
- [ ] Verify setup-helpers.mjs registers slack MCP in ~/.claude.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)