### PR TITLE
Poll Slack in notification poller every 30s

### DIFF
--- a/hooks/notification-poller
+++ b/hooks/notification-poller
@@ -9,17 +9,24 @@ NOTIFICATIONS_PORT="${RELAYGENT_NOTIFICATIONS_PORT:-$(python3 -c "import json,os
 CACHE_FILE="/tmp/relaygent-notifications-cache.json"
 NOTIFY_API="http://localhost:${NOTIFICATIONS_PORT}/notifications/pending"
 POLL_INTERVAL=1
+SLOW_POLL_EVERY=30  # Full poll (including Slack, email) every N seconds
+slow_counter=0
 
 # Write empty cache on start
 echo '[]' > "$CACHE_FILE"
 
 while true; do
-    # Poll notifications (fast mode — DB only, skip slow checks)
-    if RESULT=$(curl -sf --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null); then
-        # Only update cache on successful HTTP response with valid JSON
-        if [[ -n "$RESULT" ]] && echo "$RESULT" | python3 -c "import sys,json;json.load(sys.stdin)" 2>/dev/null; then
-            echo "$RESULT" > "${CACHE_FILE}.tmp" && mv "${CACHE_FILE}.tmp" "$CACHE_FILE"
-        fi
+    slow_counter=$((slow_counter + 1))
+    if [ "$slow_counter" -ge "$SLOW_POLL_EVERY" ]; then
+        # Full poll — includes slow collectors (Slack, email, etc.)
+        RESULT=$(curl -sf --max-time 10 "${NOTIFY_API}" 2>/dev/null)
+        slow_counter=0
+    else
+        # Fast poll — DB reminders + hub chat only
+        RESULT=$(curl -sf --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null)
+    fi
+    if [[ -n "$RESULT" ]] && echo "$RESULT" | python3 -c "import sys,json;json.load(sys.stdin)" 2>/dev/null; then
+        echo "$RESULT" > "${CACHE_FILE}.tmp" && mv "${CACHE_FILE}.tmp" "$CACHE_FILE"
     fi
     sleep "$POLL_INTERVAL"
 done


### PR DESCRIPTION
## Summary
- The notification poller was using `?fast=1` for every poll cycle, which skips slow collectors (Slack, email)
- This meant Slack messages never woke the relay from sleep — agent-one went to sleep and couldn't be reached via Slack
- Now alternates: fast poll every 1s for DB reminders + hub chat, full poll (including Slack) every 30s
- Uses a longer curl timeout (10s) for the slow poll since Slack API calls take time

## Found during
Clean reinstall of relaygent on supervised as agent-one. After the relay started, it went to sleep and never woke on Slack messages because the poller never checked Slack.

## Test plan
- [ ] Start relay, let it go to sleep
- [ ] Send a Slack DM to the agent
- [ ] Verify the agent wakes within ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)