### PR TITLE
Fix Slack wake notifications with cache-based polling

### DIFF
--- a/harness/notify_format.py
+++ b/harness/notify_format.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 def format_chat(notifs: list) -> list[str]:
-    """Format chat notification messages. Chat is owner-only — no sandboxing."""
+    """Format chat and Slack notification messages."""
     parts = []
     for msg in notifs:
-        actual = msg.get("messages", [])
-        if actual:
-            lines = [m.get("content", "") for m in actual]
+        source = msg.get("source", "chat")
+        if source == "slack":
+            count = msg.get("count", 0)
+            channels = msg.get("channels", [])
+            ch_info = ", ".join(c.get("name", c.get("id", "?")) for c in channels)
+            parts.append(f"New Slack message(s) ({count}) in: {ch_info}. Check your Slack DMs.")
+        elif msg.get("messages"):
+            lines = [m.get("content", "") for m in msg["messages"]]
             parts.append("\n".join(lines))
         else:
             parts.append("New chat message (check unread to view)")

--- a/hooks/notification-poller
+++ b/hooks/notification-poller
@@ -11,21 +11,36 @@ NOTIFY_API="http://localhost:${NOTIFICATIONS_PORT}/notifications/pending"
 POLL_INTERVAL=1
 SLOW_POLL_EVERY=30  # Full poll (including Slack, email) every N seconds
 slow_counter=0
+SLOW_CACHE="/tmp/relaygent-slow-cache.json"
 
-# Write empty cache on start
+# Write empty caches on start
 echo '[]' > "$CACHE_FILE"
+echo '[]' > "$SLOW_CACHE"
 
 while true; do
     slow_counter=$((slow_counter + 1))
     if [ "$slow_counter" -ge "$SLOW_POLL_EVERY" ]; then
         # Full poll — includes slow collectors (Slack, email, etc.)
-        RESULT=$(curl -sf --max-time 10 "${NOTIFY_API}" 2>/dev/null)
+        if SLOW_RESULT=$(curl -sf --max-time 15 "${NOTIFY_API}" 2>/dev/null); then
+            if echo "$SLOW_RESULT" | python3 -c "import sys,json;json.load(sys.stdin)" 2>/dev/null; then
+                echo "$SLOW_RESULT" > "${SLOW_CACHE}.tmp" && mv "${SLOW_CACHE}.tmp" "$SLOW_CACHE"
+            fi
+        fi
         slow_counter=0
-    else
-        # Fast poll — DB reminders + hub chat only
-        RESULT=$(curl -sf --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null)
     fi
-    if [[ -n "$RESULT" ]] && echo "$RESULT" | python3 -c "import sys,json;json.load(sys.stdin)" 2>/dev/null; then
+    # Fast poll — DB reminders + hub chat only
+    FAST_RESULT=$(curl -sf --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null)
+    # Merge: fast results + cached slow results (deduped by source)
+    RESULT=$(python3 -c "
+import json,sys
+fast = json.loads('''${FAST_RESULT:-[]}''')
+try: slow = json.load(open('$SLOW_CACHE'))
+except: slow = []
+sources = {n.get('source','') for n in fast if n.get('type')=='message'}
+merged = fast + [n for n in slow if n.get('type')=='message' and n.get('source','') not in sources]
+print(json.dumps(merged))
+" 2>/dev/null)
+    if [[ -n "$RESULT" ]]; then
         echo "$RESULT" > "${CACHE_FILE}.tmp" && mv "${CACHE_FILE}.tmp" "$CACHE_FILE"
     fi
     sleep "$POLL_INTERVAL"

--- a/notifications/routes.py
+++ b/notifications/routes.py
@@ -15,9 +15,6 @@ logger = logging.getLogger(__name__)
 
 HUB_HOST = os.environ.get("RELAYGENT_HUB_HOST", "127.0.0.1")
 HUB_PORT = os.environ.get("RELAYGENT_HUB_PORT", "8080")
-SLACK_TOKEN_PATH = os.path.join(
-    os.path.expanduser("~"), ".relaygent", "slack", "token.json"
-)
 
 
 @app.route("/notifications/pending", methods=["GET"])
@@ -123,53 +120,9 @@ def _collect_chat_messages(notifications):
         logger.warning("Failed to check hub chat for unread messages", exc_info=True)
 
 
-def _collect_slack_messages(notifications):
-    """Check Slack for unread DMs and mentions."""
-    if not os.path.exists(SLACK_TOKEN_PATH):
-        return
-    try:
-        with open(SLACK_TOKEN_PATH) as f:
-            token = json.loads(f.read()).get("access_token")
-    except (json.JSONDecodeError, OSError):
-        return
-    if not token:
-        return
-    data = json.dumps(
-        {"limit": 200, "types": "im,mpim", "exclude_archived": True}
-    ).encode()
-    req = urllib.request.Request(
-        "https://slack.com/api/conversations.list",
-        data=data,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json; charset=utf-8",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        result = json.loads(resp.read().decode())
-    if not result.get("ok"):
-        return
-    unread = [
-        c for c in (result.get("channels") or [])
-        if (c.get("unread_count_display") or 0) > 0
-    ]
-    if not unread:
-        return
-    total = sum(c.get("unread_count_display", 0) for c in unread)
-    channels = [
-        {"id": c["id"], "name": c.get("name", c["id"]),
-         "unread": c.get("unread_count_display", 0)}
-        for c in unread
-    ]
-    notifications.append({
-        "type": "message",
-        "source": "slack",
-        "count": total,
-        "channels": channels,
-    })
+import slack_collector  # noqa: E402
 
-
-_slow_collectors.append(_collect_slack_messages)
+_slow_collectors.append(slack_collector.collect)
 
 
 @app.route("/health", methods=["GET"])

--- a/notifications/slack_collector.py
+++ b/notifications/slack_collector.py
@@ -1,0 +1,127 @@
+"""Slack notification collector — checks all channels for new messages."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from config import app
+from flask import jsonify
+
+logger = logging.getLogger(__name__)
+
+SLACK_TOKEN_PATH = os.path.join(
+    os.path.expanduser("~"), ".relaygent", "slack", "token.json"
+)
+_LAST_CHECK_FILE = os.path.join(
+    os.path.expanduser("~"), ".relaygent", "slack", ".last_check_ts"
+)
+
+
+def _slack_api(token, method, params=None, _retries=2):
+    """Call a Slack Web API method. Returns parsed JSON or None.
+
+    Retries on 429 (rate limit) up to _retries times.
+    """
+    url = f"https://slack.com/api/{method}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {token}"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+        return data if data.get("ok") else None
+    except urllib.error.HTTPError as e:
+        if e.code == 429 and _retries > 0:
+            retry_after = int(e.headers.get("Retry-After", "5"))
+            logger.info(f"Slack rate limited, waiting {retry_after}s")
+            time.sleep(retry_after)
+            return _slack_api(token, method, params, _retries - 1)
+        return None
+
+
+def _load_token():
+    """Read Slack token from disk. Returns token string or None."""
+    if not os.path.exists(SLACK_TOKEN_PATH):
+        return None
+    try:
+        with open(SLACK_TOKEN_PATH) as f:
+            return json.loads(f.read()).get("access_token")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def collect(notifications):
+    """Check all Slack channels for new messages since last check.
+
+    Uses conversations.history per-channel with timestamp tracking,
+    because conversations.list doesn't return unread_count_display
+    for user (xoxp) tokens.
+    """
+    token = _load_token()
+    if not token:
+        return
+    last_ts = "0"
+    try:
+        if os.path.exists(_LAST_CHECK_FILE):
+            last_ts = open(_LAST_CHECK_FILE).read().strip() or "0"
+    except OSError:
+        pass
+
+    result = _slack_api(token, "conversations.list", {
+        "limit": 200,
+        "types": "public_channel,private_channel,im,mpim",
+        "exclude_archived": "true",
+    })
+    if not result:
+        return
+
+    skip_subtypes = {"channel_join", "joiner_notification_for_inviter"}
+    unread_channels = []
+    for ch in result.get("channels") or []:
+        hist = _slack_api(token, "conversations.history", {
+            "channel": ch["id"], "limit": 1, "oldest": last_ts,
+        })
+        if not hist:
+            continue
+        msgs = [m for m in (hist.get("messages") or [])
+                if m.get("subtype") not in skip_subtypes]
+        if msgs and msgs[0].get("ts", "0") > last_ts:
+            unread_channels.append({
+                "id": ch["id"],
+                "name": ch.get("name", ch["id"]),
+                "unread": len(msgs),
+            })
+
+    if unread_channels:
+        notifications.append({
+            "type": "message",
+            "source": "slack",
+            "count": sum(c["unread"] for c in unread_channels),
+            "channels": unread_channels,
+        })
+
+
+def ack():
+    """Advance Slack read marker to now."""
+    try:
+        os.makedirs(os.path.dirname(_LAST_CHECK_FILE), exist_ok=True)
+        with open(_LAST_CHECK_FILE, "w") as f:
+            # Use 6 decimal places to match Slack ts format
+            f.write(f"{time.time():.6f}")
+    except OSError:
+        pass
+
+
+@app.route("/notifications/ack-slack", methods=["POST"])
+def ack_slack():
+    """HTTP endpoint — called by harness after wake."""
+    ack()
+    return jsonify({"status": "ok"})

--- a/slack/slack-client.mjs
+++ b/slack/slack-client.mjs
@@ -30,13 +30,17 @@ export function getToken() {
 
 export async function slackApi(method, params = {}) {
 	const t = getToken();
+	const body = new URLSearchParams();
+	for (const [k, v] of Object.entries(params)) {
+		if (v != null) body.append(k, String(v));
+	}
 	const res = await fetch(`${BASE_URL}/${method}`, {
 		method: "POST",
 		headers: {
 			"Authorization": `Bearer ${t}`,
-			"Content-Type": "application/json; charset=utf-8",
+			"Content-Type": "application/x-www-form-urlencoded",
 		},
-		body: JSON.stringify(params),
+		body: body.toString(),
 	});
 	if (res.status === 429) {
 		const retry = parseInt(res.headers.get("Retry-After") || "5", 10);


### PR DESCRIPTION
## Summary

- **Fixes 3 bugs** preventing Slack messages from waking the relay:
  1. `conversations.list` doesn't return `unread_count_display` for user (xoxp) tokens — replaced with `conversations.history` per-channel with timestamp tracking
  2. `_extract_timestamps` in session.py returned empty set for Slack notifications (no `messages` key) — added channel-based dedup keys with unread count
  3. `time.time()` produces 7+ decimal places but Slack's `oldest` parameter needs 6 — fixed timestamp format in ack

- **Session reads cached notification file** instead of hitting the API directly, avoiding Slack rate limits during 1s fast polls (agent-one's improvement)
- **Notification poller merges slow cache** with fast results so Slack notifications persist between 30s slow poll cycles
- **429 rate-limit retry** added to Python Slack API helper
- **slack-client.mjs** switched to `application/x-www-form-urlencoded` (agent-one found Slack's read endpoints don't properly accept JSON body)
- **Extracted** Slack collector to `notifications/slack_collector.py` to keep `routes.py` under 200 lines
- **All channel types** checked (public, private, DM, group DM) + filters `joiner_notification_for_inviter` subtype

## Files changed (6)
- `notifications/slack_collector.py` — NEW: extracted Slack collector with history-based detection, 429 retry, ack endpoint
- `notifications/routes.py` — removed inline Slack code, imports from slack_collector
- `harness/session.py` — reads cache file instead of HTTP, Slack dedup keys, ack after wake, stale cache detection
- `harness/notify_format.py` — Slack-aware wake message formatting
- `hooks/notification-poller` — slow cache + fast merge for sticky Slack notifications
- `slack/slack-client.mjs` — URLSearchParams + form-urlencoded content type

## Test plan
- [x] Deployed fixes to supervised, agent-one woke from Slack DM successfully
- [x] Notification endpoint detects new Slack messages via conversations.history
- [x] 429 rate-limit retry prevents silent failures
- [x] Timestamp format fix (6 decimal places) verified — `oldest` parameter now works
- [ ] Full sleep → Slack DM → wake cycle (in progress, agent-one currently active)

Co-authored with agent-one (supervised) who identified the cache-based polling approach, all-channel-types fix, and urlencoded content-type bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)