### PR TITLE
Fix CSRF blocking hub form submissions over non-localhost origins

### DIFF
--- a/hub/svelte.config.js
+++ b/hub/svelte.config.js
@@ -4,5 +4,11 @@ import adapter from '@sveltejs/adapter-node';
 export default {
 	kit: {
 		adapter: adapter({ out: 'build' }),
+		csrf: {
+			// Hub is internal-only (local network), not exposed to public internet.
+			// Non-localhost origins don't match the server's origin, triggering
+			// SvelteKit's built-in CSRF protection. Safe to disable for internal tool.
+			checkOrigin: false,
+		},
 	}
 };


### PR DESCRIPTION
## Summary
- Disable SvelteKit's origin-based CSRF check for the hub
- The hub is internal-only (local network), never exposed to public internet
- Non-localhost origins don't match the server's origin, causing 403 "Cross-site POST form submissions are forbidden" when editing intent or KB topics

## Test plan
- [ ] Access hub over local network and submit the intent edit form
- [ ] Verify KB topic editing also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)