### PR TITLE
Reset context warning flag on session resume

### DIFF
--- a/harness/process.py
+++ b/harness/process.py
@@ -1,5 +1,4 @@
 """Claude subprocess management with hang detection."""
-
 from __future__ import annotations
 
 import subprocess
@@ -116,6 +115,7 @@ class ClaudeProcess:
 
     def resume(self, message: str) -> int:
         self._terminate()
+        self._context_warning_sent = False
         log_start = self._get_log_lines()
         self._log_file = self._open_log()
         settings_file = str(Path(__file__).parent / "settings.json")


### PR DESCRIPTION
## Summary
- `_context_warning_sent` was never reset between resume cycles, so if a session was resumed after a hang, the context fill warning would never fire again
- Now resets the flag at the start of `resume()` so each monitoring cycle can independently detect context threshold

## Test plan
- [ ] Resume a session after hang — verify context warning still fires
- [ ] Verify normal session flow unchanged