### PR TITLE
Fix Slack notifications not waking agent from sleep

### DIFF
--- a/harness/session.py
+++ b/harness/session.py
@@ -89,8 +89,21 @@ class SleepManager:
         except Exception:
             pass  # Best-effort
 
+    def _clear_slack_dedup(self) -> None:
+        """Clear Slack dedup keys so new messages always trigger wake.
+
+        Slack unreads can't be marked as read (missing write scopes),
+        so the same dedup keys persist and block real new messages.
+        Clearing on sleep entry ensures any change in unread state wakes us.
+        """
+        self._seen_timestamps = {
+            ts for ts in self._seen_timestamps
+            if not ts.startswith("slack-")
+        }
+
     def _wait_for_wake(self) -> tuple[bool, list]:
         """Poll cache file for wake condition. Returns (woken, notifications)."""
+        self._clear_slack_dedup()
         set_status("sleeping")
         log("Sleeping, waiting for notifications...")
 

--- a/hooks/notification-poller
+++ b/hooks/notification-poller
@@ -9,7 +9,7 @@ NOTIFICATIONS_PORT="${RELAYGENT_NOTIFICATIONS_PORT:-$(python3 -c "import json,os
 CACHE_FILE="/tmp/relaygent-notifications-cache.json"
 NOTIFY_API="http://localhost:${NOTIFICATIONS_PORT}/notifications/pending"
 POLL_INTERVAL=1
-SLOW_POLL_EVERY=30  # Full poll (including Slack, email) every N seconds
+SLOW_POLL_EVERY=10  # Full poll (including Slack, email) every N seconds
 slow_counter=0
 SLOW_CACHE="/tmp/relaygent-slow-cache.json"
 


### PR DESCRIPTION
## Summary
- Clear Slack dedup keys from `SleepManager._seen_timestamps` when entering sleep, so phantom unreads (from missing write scopes) don't block real new messages from triggering wake
- Reduce slow poll interval from 30s to 10s for faster Slack notification detection

## Root Cause
The dedup cache used keys like `slack-{channel_id}-{unread_count}`. Since we can't mark channels as read (token lacks write scopes), the same keys persisted across sleep/wake cycles. Once a channel's unread state was "seen", no new messages in that channel could trigger a wake unless the unread count changed.

## Test plan
- [ ] Sleep the agent, send a Slack message, verify it wakes within ~10s
- [ ] Verify repeated sleep/wake cycles don't accumulate stale dedup keys
- [ ] Verify non-Slack notifications (hub chat, reminders) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)