### PR TITLE
Use configurable context window in hook

### DIFF
--- a/hooks/check-notifications
+++ b/hooks/check-notifications
@@ -66,7 +66,7 @@ if [[ -n "$REPO_PATH" ]]; then
 fi
 if [[ -n "$LATEST_JSONL" ]]; then
     FILL_PCT=$(tail -c 65536 "$LATEST_JSONL" 2>/dev/null | python3 -c "
-import sys, json
+import sys, json, os
 data = sys.stdin.buffer.read().decode('utf-8', errors='ignore')
 for line in reversed(data.strip().split(chr(10))):
     try:
@@ -75,7 +75,8 @@ for line in reversed(data.strip().split(chr(10))):
             usage = entry.get('message', {}).get('usage', {})
             if usage:
                 total = usage.get('input_tokens', 0) + usage.get('output_tokens', 0) + usage.get('cache_creation_input_tokens', 0) + usage.get('cache_read_input_tokens', 0)
-                print(int(total / 200000 * 100))
+                ctx_window = int(os.environ.get('RELAYGENT_CONTEXT_WINDOW', '200000'))
+                print(int(total / ctx_window * 100))
                 break
     except: continue
 " 2>/dev/null)


### PR DESCRIPTION
## Summary
- The check-notifications hook hardcoded `200000` for context window size when calculating fill percentage
- Now reads `RELAYGENT_CONTEXT_WINDOW` env var (same as PR #81), falling back to 200000
- Companion to #81 — ensures both the harness and the hook use the same configurable value

## Test plan
- [ ] Set `RELAYGENT_CONTEXT_WINDOW=128000` — verify context % is calculated with 128k denominator
- [ ] Without env var — verify default 200000 still works