### PR TITLE
Replace encrypted vault with dotfile secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,14 @@ Create additional topic files as needed. The agent links them together with `[[w
 
 ## Email & Secrets
 
-**Secrets vault.** The agent has an encrypted credential store (`~/.relaygent/secrets.enc`) using AES-256-GCM with PBKDF2 key derivation. Setup prompts for a master password, which encrypts all stored credentials. The agent accesses secrets through MCP tools (`secrets_get`, `secrets_set`, `secrets_list`, `secrets_delete`).
+**Secrets.** Credentials are stored in `~/.relaygent/secrets.json` with `chmod 600` file permissions — the same approach used by gh, aws, gcloud, and docker. No encryption, no master password. The agent accesses secrets through MCP tools (`secrets_get`, `secrets_set`, `secrets_list`, `secrets_delete`).
 
 **Gmail integration.** Each agent gets its own email address as identity. The `email` MCP provides 6 tools: `search_emails`, `read_email`, `send_email`, `draft_email`, `modify_email`, and `list_email_labels`. OAuth2 credentials are stored at `~/.relaygent/gmail/`.
 
 **Setup flow:**
-1. During `./setup.sh`, you're prompted for a master password and email password
-2. The vault is created and the email password is stored
-3. On `relaygent start`, you enter the master password — it flows to MCP servers via environment
-4. Gmail OAuth is completed on the agent's first session (it visits the auth URL via computer-use)
+1. During `./setup.sh`, you optionally provide an email and password
+2. Secrets are stored in `~/.relaygent/secrets.json` (file-permission protected)
+3. Gmail OAuth is completed on the agent's first session (it visits the auth URL via computer-use)
 
 **Google Cloud setup** (required for Gmail): Create an OAuth2 client in [Google Cloud Console](https://console.cloud.google.com/), download the keys JSON, and save it as `~/.relaygent/gmail/gcp-oauth.keys.json`. The agent completes the OAuth flow automatically.
 
@@ -141,7 +140,7 @@ relaygent/
 ├── notifications/    # Reminder + wake trigger service (Python/Flask + MCP)
 ├── forum/            # Cross-session discussion board (Python/Flask)
 ├── email/            # Gmail MCP server (OAuth2, 6 tools)
-├── secrets/          # Encrypted credential vault (AES-256-GCM + MCP)
+├── secrets/          # Credential store (dotfile JSON + MCP)
 ├── hooks/            # PostToolUse hook (time, notifications, context tracking)
 ├── templates/        # Starter KB files for new installations
 ├── scripts/          # Pre-commit hook (200-line file limit enforcement)

--- a/bin/relaygent
+++ b/bin/relaygent
@@ -86,12 +86,6 @@ check_process() {
 
 do_start() {
     load_config
-    # Secrets vault — master password needed for MCP servers
-    if [ -f "$HOME/.relaygent/secrets.enc" ] && [ -z "${RELAYGENT_MASTER_PASSWORD:-}" ]; then
-        echo -ne "${CYAN}Master password:${NC} "
-        read -rs RELAYGENT_MASTER_PASSWORD; echo
-        export RELAYGENT_MASTER_PASSWORD
-    fi
     echo -e "${CYAN}Starting Relaygent...${NC}"
     local port_ok=true
     check_port "$HUB_PORT" "Hub" || port_ok=false

--- a/secrets/cli.mjs
+++ b/secrets/cli.mjs
@@ -1,61 +1,46 @@
 #!/usr/bin/env node
 /**
- * Secrets vault CLI — get/set/list/delete encrypted secrets.
+ * Secrets CLI — get/set/list/delete secrets.
  * Usage: node cli.mjs <get|set|list|delete> [name] [value]
- * Master password read from RELAYGENT_MASTER_PASSWORD env var or prompted.
  */
-import { createInterface } from "readline";
-import { getSecret, setSecret, listSecrets, deleteSecret, vaultExists, createVault } from "./vault.mjs";
+import { getSecret, setSecret, listSecrets, deleteSecret, createVault, vaultExists } from "./vault.mjs";
 
 const [,, cmd, name, ...rest] = process.argv;
 const value = rest.join(" ");
 
-function promptPassword() {
-	return new Promise(resolve => {
-		const rl = createInterface({ input: process.stdin, output: process.stderr });
-		process.stderr.write("Master password: ");
-		rl.question("", answer => { rl.close(); resolve(answer.trim()); });
-	});
+if (!vaultExists() && cmd !== "init") {
+	console.error("No secrets file found. Run setup or: node cli.mjs init");
+	process.exit(1);
 }
 
-async function main() {
-	const password = process.env.RELAYGENT_MASTER_PASSWORD || await promptPassword();
-	if (!password) { console.error("No password provided."); process.exit(1); }
-
-	if (!vaultExists() && cmd !== "init") {
-		console.error("No vault found. Run setup or: node cli.mjs init"); process.exit(1);
+switch (cmd) {
+	case "init":
+		if (vaultExists()) { console.error("Secrets file already exists."); process.exit(1); }
+		createVault();
+		console.log("Secrets file created.");
+		break;
+	case "get":
+		if (!name) { console.error("Usage: secrets get <name>"); process.exit(1); }
+		const val = getSecret(name);
+		if (val === null) { console.error(`Secret "${name}" not found.`); process.exit(1); }
+		process.stdout.write(val);
+		break;
+	case "set":
+		if (!name || !value) { console.error("Usage: secrets set <name> <value>"); process.exit(1); }
+		setSecret(name, value);
+		console.error(`Secret "${name}" stored.`);
+		break;
+	case "list": {
+		const keys = listSecrets();
+		if (keys.length) console.log(keys.join("\n"));
+		else console.log("(empty)");
+		break;
 	}
-
-	switch (cmd) {
-		case "init":
-			if (vaultExists()) { console.error("Vault already exists."); process.exit(1); }
-			createVault(password);
-			console.log("Vault created.");
-			break;
-		case "get":
-			if (!name) { console.error("Usage: secrets get <name>"); process.exit(1); }
-			const val = getSecret(password, name);
-			if (val === null) { console.error(`Secret "${name}" not found.`); process.exit(1); }
-			process.stdout.write(val);
-			break;
-		case "set":
-			if (!name || !value) { console.error("Usage: secrets set <name> <value>"); process.exit(1); }
-			setSecret(password, name, value);
-			console.error(`Secret "${name}" stored.`);
-			break;
-		case "list":
-			const keys = listSecrets(password);
-			if (keys.length) console.log(keys.join("\n"));
-			else console.log("(empty)");
-			break;
-		case "delete":
-			if (!name) { console.error("Usage: secrets delete <name>"); process.exit(1); }
-			deleteSecret(password, name);
-			console.error(`Secret "${name}" deleted.`);
-			break;
-		default:
-			console.log("Usage: secrets <get|set|list|delete|init> [name] [value]");
-	}
+	case "delete":
+		if (!name) { console.error("Usage: secrets delete <name>"); process.exit(1); }
+		deleteSecret(name);
+		console.error(`Secret "${name}" deleted.`);
+		break;
+	default:
+		console.log("Usage: secrets <get|set|list|delete|init> [name] [value]");
 }
-
-main().catch(e => { console.error(e.message); process.exit(1); });

--- a/secrets/mcp-server.mjs
+++ b/secrets/mcp-server.mjs
@@ -1,62 +1,53 @@
 #!/usr/bin/env node
 /**
- * Secrets MCP server — exposes vault get/set/list/delete to Claude.
- * Master password via RELAYGENT_MASTER_PASSWORD env var.
+ * Secrets MCP server — exposes get/set/list/delete to Claude.
+ * Secrets stored as JSON with file-permission protection (chmod 600).
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { getSecret, setSecret, listSecrets, deleteSecret, vaultExists } from "./vault.mjs";
+import { getSecret, setSecret, listSecrets, deleteSecret, createVault, vaultExists } from "./vault.mjs";
 
-const password = process.env.RELAYGENT_MASTER_PASSWORD;
-if (!password) {
-	process.stderr.write("[secrets] ERROR: RELAYGENT_MASTER_PASSWORD not set.\n");
-	process.stderr.write("[secrets] Start with: relaygent start (prompts for password)\n");
-	process.stderr.write("[secrets] Or set: export RELAYGENT_MASTER_PASSWORD=<your-password>\n");
-	process.exit(1);
-}
-
-const server = new McpServer({ name: "secrets", version: "1.0.0" });
+const server = new McpServer({ name: "secrets", version: "2.0.0" });
 const txt = (t) => ({ content: [{ type: "text", text: t }] });
 
-server.tool("secrets_get", "Get a secret by name. Output goes to stdout only (safe for passwords).",
+// Auto-create secrets file if it doesn't exist
+if (!vaultExists()) createVault();
+
+server.tool("secrets_get", "Get a secret by name.",
 	{ name: z.string().describe("Secret name") },
 	async ({ name }) => {
-		if (!vaultExists()) return txt("Error: vault not found. Run setup first.");
 		try {
-			const val = getSecret(password, name);
+			const val = getSecret(name);
 			return val !== null ? txt(val) : txt(`Secret "${name}" not found.`);
 		} catch (e) { return txt(`Error: ${e.message}`); }
 	}
 );
 
-server.tool("secrets_set", "Store a secret in the encrypted vault.",
+server.tool("secrets_set", "Store a secret.",
 	{ name: z.string().describe("Secret name"), value: z.string().describe("Secret value") },
 	async ({ name, value }) => {
-		if (!vaultExists()) return txt("Error: vault not found. Run setup first.");
 		try {
-			setSecret(password, name, value);
+			setSecret(name, value);
 			return txt(`Secret "${name}" stored.`);
 		} catch (e) { return txt(`Error: ${e.message}`); }
 	}
 );
 
-server.tool("secrets_list", "List all secret names in the vault.", {},
+server.tool("secrets_list", "List all secret names.", {},
 	async () => {
-		if (!vaultExists()) return txt("Error: vault not found. Run setup first.");
 		try {
-			const keys = listSecrets(password);
+			const keys = listSecrets();
 			return keys.length ? txt(keys.join("\n")) : txt("(empty)");
 		} catch (e) { return txt(`Error: ${e.message}`); }
 	}
 );
 
-server.tool("secrets_delete", "Delete a secret from the vault.",
+server.tool("secrets_delete", "Delete a secret.",
 	{ name: z.string().describe("Secret name to delete") },
 	async ({ name }) => {
-		if (!vaultExists()) return txt("Error: vault not found. Run setup first.");
 		try {
-			deleteSecret(password, name);
+			deleteSecret(name);
 			return txt(`Secret "${name}" deleted.`);
 		} catch (e) { return txt(`Error: ${e.message}`); }
 	}

--- a/setup-helpers.mjs
+++ b/setup-helpers.mjs
@@ -4,16 +4,16 @@ import { mkdirSync, writeFileSync, readFileSync, copyFileSync } from 'fs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 
-export async function setupSecrets(REPO_DIR, masterPassword, emailPassword, C) {
+export async function setupSecrets(REPO_DIR, emailPassword, C) {
 	const { createVault, vaultExists, setSecret } = await import(pathToFileURL(join(REPO_DIR, 'secrets', 'vault.mjs')).href);
 	if (!vaultExists()) {
-		createVault(masterPassword);
-		console.log(`  Secrets vault: ${C.green}created${C.reset}`);
+		createVault();
+		console.log(`  Secrets: ${C.green}created${C.reset} (~/.relaygent/secrets.json)`);
 	} else {
-		console.log(`  Secrets vault: ${C.green}exists${C.reset}`);
+		console.log(`  Secrets: ${C.green}exists${C.reset}`);
 	}
 	if (emailPassword) {
-		setSecret(masterPassword, 'email-password', emailPassword);
+		setSecret('email-password', emailPassword);
 		console.log(`  Secret stored: ${C.green}email-password${C.reset}`);
 	}
 }

--- a/setup.mjs
+++ b/setup.mjs
@@ -47,13 +47,6 @@ async function main() {
 	const agentName = agentNameInput || 'relaygent';
 	const agentEmail = (await ask(`${C.cyan}Agent email (optional, for identity/services):${C.reset} `)).trim();
 
-	// Secrets vault — encrypted credential storage
-	const masterPassword = (await ask(`${C.cyan}Master password (encrypts stored credentials):${C.reset} `)).trim();
-	if (!masterPassword) {
-		console.log(`${C.red}Master password required for credential vault.${C.reset}`);
-		rl.close();
-		process.exit(1);
-	}
 	const emailPassword = agentEmail
 		? (await ask(`${C.cyan}Email password (for ${agentEmail}):${C.reset} `)).trim()
 		: '';
@@ -144,8 +137,8 @@ async function main() {
 	execSync('npm run build', { cwd: join(REPO_DIR, 'hub'), stdio: 'pipe' });
 	console.log(`  Hub: ${C.green}built${C.reset}`);
 
-	// Create secrets vault and store credentials
-	await setupSecrets(REPO_DIR, masterPassword, emailPassword, C);
+	// Create secrets file and store credentials
+	await setupSecrets(REPO_DIR, emailPassword, C);
 
 	// Set up Hammerspoon (computer-use)
 	await setupHammerspoon(config, REPO_DIR, HOME, C, ask);


### PR DESCRIPTION
## Summary

Replaces the AES-256-GCM encrypted vault with a simple JSON dotfile (`~/.relaygent/secrets.json`, chmod 600) — the same pattern used by gh, aws, gcloud, and docker.

- **No more master password** — no prompt during setup or start
- **7 files changed, -74 lines net** — simpler onboarding, less code to maintain
- Supersedes PR #85 (password masking) since there's no password to mask anymore

### Changes
- `secrets/vault.mjs` — plain JSON read/write with atomic rename + chmod 600
- `secrets/cli.mjs` — remove password argument from all commands
- `secrets/mcp-server.mjs` — remove password from environment, auto-create file
- `setup.mjs` — remove master password prompt
- `setup-helpers.mjs` — remove password args from setupSecrets
- `bin/relaygent` — remove master password prompt from do_start
- `README.md` — update docs

## Context

Preston tested a fresh clone and hit two issues: password shown in plaintext and asked twice. Rather than patching the symptoms, we discussed options in #public-relaygent-repo and he chose the dotfile approach — leaning on the wisdom of what gh/aws/gcloud have done.

## Test plan

- [ ] Fresh clone → `./setup.sh` → no password prompt, secrets.json created with 600 perms
- [ ] `relaygent start` → no password prompt, services start normally
- [ ] `node secrets/cli.mjs set foo bar` → stores secret
- [ ] `node secrets/cli.mjs get foo` → returns "bar"
- [ ] Verify `ls -la ~/.relaygent/secrets.json` shows `-rw-------`