### PR TITLE
Fix JSON injection in notification-poller

### DIFF
--- a/hooks/notification-poller
+++ b/hooks/notification-poller
@@ -31,10 +31,12 @@ while true; do
     # Fast poll — DB reminders + hub chat only
     FAST_RESULT=$(curl -sf --max-time 3 "${NOTIFY_API}?fast=1" 2>/dev/null)
     # Merge: fast results + cached slow results (deduped by source)
-    RESULT=$(python3 -c "
-import json,sys
-fast = json.loads('''${FAST_RESULT:-[]}''')
-try: slow = json.load(open('$SLOW_CACHE'))
+    # Pass data via env vars — shell interpolation into Python strings breaks on
+    # backslashes, triple quotes, or empty results
+    RESULT=$(FAST_JSON="${FAST_RESULT:-[]}" SLOW_FILE="$SLOW_CACHE" python3 -c "
+import json,os
+fast = json.loads(os.environ.get('FAST_JSON','[]'))
+try: slow = json.load(open(os.environ['SLOW_FILE']))
 except: slow = []
 sources = {n.get('source','') for n in fast if n.get('type')=='message'}
 merged = fast + [n for n in slow if n.get('type')=='message' and n.get('source','') not in sources]


### PR DESCRIPTION
## Summary
- The `FAST_RESULT` shell variable was interpolated directly into a Python triple-quoted string (`'''${FAST_RESULT:-[]}'''`), which breaks if the API returns JSON containing backslashes, triple quotes, or empty strings
- Now passes data via environment variables (`FAST_JSON`, `SLOW_FILE`) and reads with `os.environ` — safe regardless of content

## Test plan
- [ ] `notification-poller` starts and polls correctly
- [ ] Cache file is updated with merged fast+slow results
- [ ] No breakage when API returns special characters in message content

🤖 Generated with [Claude Code](https://claude.com/claude-code)