### PR TITLE
Fix resource leak, API error handling, and DB timeout

### DIFF
--- a/hub/mcp-chat.mjs
+++ b/hub/mcp-chat.mjs
@@ -17,6 +17,7 @@ async function api(path, method = "GET", body = null) {
 	const opts = { method, headers: { "Content-Type": "application/json" } };
 	if (body) opts.body = JSON.stringify(body);
 	const res = await fetch(`${API}${path}`, opts);
+	if (!res.ok) throw new Error(`Hub API ${method} ${path}: ${res.status} ${res.statusText}`);
 	return res.json();
 }
 

--- a/hub/src/lib/chat.js
+++ b/hub/src/lib/chat.js
@@ -14,7 +14,7 @@ let db;
 function getDb() {
 	if (db) return db;
 	fs.mkdirSync(DB_DIR, { recursive: true });
-	db = new Database(DB_PATH);
+	db = new Database(DB_PATH, { timeout: 5000 });
 	db.pragma('journal_mode = WAL');
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS messages (

--- a/notifications/slack_collector.py
+++ b/notifications/slack_collector.py
@@ -71,7 +71,8 @@ def collect(notifications):
     last_ts = "0"
     try:
         if os.path.exists(_LAST_CHECK_FILE):
-            last_ts = open(_LAST_CHECK_FILE).read().strip() or "0"
+            with open(_LAST_CHECK_FILE) as f:
+                last_ts = f.read().strip() or "0"
     except OSError:
         pass
 


### PR DESCRIPTION
## Summary
- **Slack collector file descriptor leak**: `open().read()` without context manager leaked a file handle on every poll cycle. Now uses `with open()`.
- **MCP chat API error handling**: `api()` called `res.json()` without checking `res.ok` first. A non-200 response (hub down, bad route) would produce a cryptic JSON parse error instead of a clear message. Now throws with status code and text.
- **SQLite busy timeout**: `new Database(DB_PATH)` had no timeout, so concurrent writes would throw `SQLITE_BUSY` immediately. Now waits up to 5s for the lock.

## Test plan
- [x] All 71 existing tests pass
- [ ] Verify hub chat MCP still works (read/send/mark_read)
- [ ] Verify Slack notifications still collected correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)