### PR TITLE
Add WAL mode to notifications DB, cap Slack retry loop

### DIFF
--- a/notifications/db.py
+++ b/notifications/db.py
@@ -11,8 +11,9 @@ from config import DB_PATH
 def get_db():
     """Yield a SQLite connection that is closed when the context exits."""
     os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(DB_PATH, timeout=5)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
     try:
         yield conn
     finally:

--- a/slack/slack-client.mjs
+++ b/slack/slack-client.mjs
@@ -28,7 +28,9 @@ export function getToken() {
 	return token;
 }
 
-export async function slackApi(method, params = {}) {
+const MAX_RETRIES = 3;
+
+export async function slackApi(method, params = {}, _retries = 0) {
 	const t = getToken();
 	const body = new URLSearchParams();
 	for (const [k, v] of Object.entries(params)) {
@@ -43,10 +45,11 @@ export async function slackApi(method, params = {}) {
 		body: body.toString(),
 	});
 	if (res.status === 429) {
+		if (_retries >= MAX_RETRIES) throw new Error(`Slack ${method}: rate limited after ${MAX_RETRIES} retries`);
 		const retry = parseInt(res.headers.get("Retry-After") || "5", 10);
-		process.stderr.write(`[slack] Rate limited, retrying in ${retry}s\n`);
+		process.stderr.write(`[slack] Rate limited, retrying in ${retry}s (${_retries + 1}/${MAX_RETRIES})\n`);
 		await new Promise(r => setTimeout(r, retry * 1000));
-		return slackApi(method, params);
+		return slackApi(method, params, _retries + 1);
 	}
 	const data = await res.json();
 	if (!data.ok) throw new Error(`Slack ${method}: ${data.error}`);


### PR DESCRIPTION
## Summary
- **notifications/db.py**: Add WAL journal mode and 5s busy timeout, matching forum and hub chat DB configs. Prevents "database is locked" errors under concurrent access from the notification poller.
- **slack/slack-client.mjs**: Cap 429 rate-limit retry at 3 attempts. Previously retried indefinitely via recursion, risking stack overflow under persistent rate limiting.

## Test plan
- [ ] Verify notifications service starts correctly with WAL mode
- [ ] Verify Slack MCP tools still work (send, read, channels)
- [ ] Verify Slack rate limit retry logs show attempt count

🤖 Generated with [Claude Code](https://claude.com/claude-code)