### PR TITLE
Cap pendingTools map size to prevent memory leak

### DIFF
--- a/hub/server.js
+++ b/hub/server.js
@@ -29,6 +29,7 @@ server.on('upgrade', (req, socket, head) => {
 });
 
 const pendingTools = new Map();
+const MAX_PENDING = 200;
 
 function parseSessionLine(line) {
 	try {
@@ -46,6 +47,11 @@ function parseSessionLine(line) {
 						toolUseId: item.id,
 					};
 					pendingTools.set(item.id, activity);
+					// Evict oldest entries if map grows too large
+					if (pendingTools.size > MAX_PENDING) {
+						const oldest = pendingTools.keys().next().value;
+						pendingTools.delete(oldest);
+					}
 					activities.push(activity);
 				} else if (item?.type === 'text' && item.text?.length > 10) {
 					activities.push({ type: 'text', time: entry.timestamp, text: item.text });


### PR DESCRIPTION
## Summary
- The `pendingTools` Map in `hub/server.js` tracks tool_use entries waiting for matching tool_result responses. If a session crashes mid-tool or results are never received, entries accumulate indefinitely.
- Adds a `MAX_PENDING=200` cap with FIFO eviction — when the map exceeds 200 entries, the oldest entry is removed.
- The map is already cleared on session switch (line 83), so this is a safety net for within-session accumulation.

## Test plan
- [ ] Verify relay activity feed still shows tool use/results correctly
- [ ] Verify session switching still works (pendingTools.clear() unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)