### PR TITLE
Fix command injection in setup.mjs git init

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -92,16 +92,14 @@ async function main() {
 	}
 	console.log(`  KB templates: ${KB_DIR}`);
 
-	// Init git for KB
+	// Init git for KB (use spawnSync to avoid shell injection from user input)
 	if (!existsSync(join(kbRoot, '.git'))) {
-		const gitCmds = [
-			'git init',
-			`git config user.name "${agentName}"`,
-			`git config user.email "${agentEmail || `${agentName}@localhost`}"`,
-			'git add -A',
-			'git commit -m "Initial KB"',
-		].join(' && ');
-		execSync(gitCmds, { cwd: kbRoot, stdio: 'pipe' });
+		const gitOpts = { cwd: kbRoot, stdio: 'pipe' };
+		spawnSync('git', ['init'], gitOpts);
+		spawnSync('git', ['config', 'user.name', agentName], gitOpts);
+		spawnSync('git', ['config', 'user.email', agentEmail || `${agentName}@localhost`], gitOpts);
+		spawnSync('git', ['add', '-A'], gitOpts);
+		spawnSync('git', ['commit', '-m', 'Initial KB'], gitOpts);
 		console.log(`  KB git: initialized`);
 	}
 


### PR DESCRIPTION
## Summary
- User-provided `agentName` and `agentEmail` were interpolated directly into a shell command string via `execSync`. A name containing `"` or `$()` could execute arbitrary commands.
- Replaced with `spawnSync` calls that pass arguments as an array, bypassing shell interpretation entirely.
- Other `execSync` calls in the file use hardcoded strings and are unaffected.

## Test plan
- [ ] Run `node setup.mjs` and verify KB git init works with a normal agent name
- [ ] Verify agent name with special characters (e.g., `test"agent`) doesn't break

🤖 Generated with [Claude Code](https://claude.com/claude-code)