### PR TITLE
Replace bare except clauses in computer-use modules

### DIFF
--- a/computer-use/linux-server.py
+++ b/computer-use/linux-server.py
@@ -36,7 +36,7 @@ class Handler(BaseHTTPRequestHandler):
             return {}
         try:
             return json.loads(self.rfile.read(length))
-        except Exception:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             return {}
 
     def do_GET(self):


### PR DESCRIPTION
## Summary
- Replace 15+ bare `except Exception:` / `except: pass` blocks with specific exception types across `linux_a11y.py`, `linux_display.py`, and `linux-server.py`
- AT-SPI2 operations: catch `(RuntimeError, AttributeError, NotImplementedError)` — the actual failure modes for D-Bus/accessibility tree traversal
- Subprocess operations: catch `(subprocess.SubprocessError, FileNotFoundError, ValueError)` — covers xdotool/wmctrl not installed, process errors, and parse failures
- JSON parsing: catch `(json.JSONDecodeError, UnicodeDecodeError)` — the specific HTTP body parse failures
- Add module-level loggers to `linux_a11y.py` and `linux_display.py` for debug visibility

## Why
Bare `except Exception:` catches everything including `SystemExit` and `KeyboardInterrupt`, hides real errors, and makes debugging impossible. These specific types match the documented failure modes of each library/tool.

## Test plan
- [x] All 88 existing harness tests pass
- [x] All 3 files compile clean (`py_compile`)
- [x] All files under 200-line limit
- [ ] Manual testing with Linux computer-use server (requires Docker/VM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)