### PR TITLE
Improve error handling and logging in notifications

### DIFF
--- a/notifications/routes.py
+++ b/notifications/routes.py
@@ -116,7 +116,7 @@ def _collect_chat_messages(notifications):
                 "count": data["count"],
                 "messages": messages,
             })
-    except Exception:
+    except (urllib.error.URLError, json.JSONDecodeError, OSError):
         logger.warning("Failed to check hub chat for unread messages", exc_info=True)
 
 


### PR DESCRIPTION
## Summary
- Add logging for silent failures in `slack_collector.py` — file I/O errors on timestamp read/write, Slack API HTTP errors, and network failures were all silently swallowed
- Catch `URLError`/`OSError` separately from `HTTPError` in `_slack_api()` so network failures are logged
- Log `ok=false` Slack API responses at debug level for troubleshooting
- Narrow bare `except Exception` in `routes.py` `_collect_chat_messages` to `(URLError, JSONDecodeError, OSError)`

## Why
Silent failures in the notification pipeline make debugging missed notifications nearly impossible. Every previous Slack wake bug was invisible until manual investigation because errors were swallowed with `pass`.

## Test plan
- [x] All 88 harness tests pass
- [x] Both files compile clean
- [x] Both files under 200-line limit
- [ ] Verify Slack notification flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)