### PR TITLE
Narrow bare exceptions in harness utilities

### DIFF
--- a/harness/relay_utils.py
+++ b/harness/relay_utils.py
@@ -54,6 +54,7 @@ def notify_crash(crash_count: int, exit_code: int) -> None:
 def _send_chat_alert(message: str) -> None:
     """Best-effort alert to owner via hub chat."""
     import json
+    import urllib.error
     import urllib.request
     hub_port = os.environ.get("RELAYGENT_HUB_PORT", "8080")
     url = f"http://127.0.0.1:{hub_port}/api/chat"
@@ -63,7 +64,7 @@ def _send_chat_alert(message: str) -> None:
             url, data=data, headers={"Content-Type": "application/json"},
         )
         urllib.request.urlopen(req, timeout=5)
-    except Exception as e:
+    except (urllib.error.URLError, OSError) as e:
         log(f"Chat alert failed (hub may be down): {e}")
 
 
@@ -76,7 +77,7 @@ def commit_kb() -> None:
             env["RELAY_RUN"] = "1"
             subprocess.run([str(commit_script)], env=env, capture_output=True, timeout=30)
             log("KB changes committed")
-        except Exception as e:
+        except (subprocess.SubprocessError, OSError) as e:
             log(f"KB commit failed: {e}")
 
 

--- a/harness/session.py
+++ b/harness/session.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import time
+import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
@@ -87,7 +88,7 @@ class SleepManager:
             ack_url = f"http://127.0.0.1:{NOTIFICATIONS_PORT}/notifications/ack-slack"
             req = urllib.request.Request(ack_url, method="POST", data=b"")
             urllib.request.urlopen(req, timeout=3)
-        except Exception:
+        except (urllib.error.URLError, OSError):
             pass  # Best-effort
 
     def _wait_for_wake(self) -> tuple[bool, list]:


### PR DESCRIPTION
## Summary
- `relay_utils.py`: `_send_chat_alert` catches `(URLError, OSError)` instead of bare `Exception`
- `relay_utils.py`: `commit_kb` catches `(SubprocessError, OSError)` instead of bare `Exception`
- `session.py`: `_ack_slack` catches `(URLError, OSError)` instead of bare `Exception`

## Why
All three functions are best-effort with fallback logging, but bare `Exception` masks programming errors (`TypeError`, `AttributeError`, etc.) that should propagate. The narrowed types match the actual failure modes: HTTP/network errors for chat alerts and Slack acks, subprocess/file errors for KB commits.

## Test plan
- [x] All 88 harness tests pass
- [x] Both files compile clean
- [x] Both files under 200-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)