### PR TITLE
Expand .gitignore with security-sensitive patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,16 @@ harness/settings.json
 knowledge/
 data/
 logs/
+
+# Secrets and credentials
+.env
+.env.*
+*.key
+*.pem
+credentials.json
+secrets.json
+
+# SQLite temp files
+*.db-shm
+*.db-wal
+*.db-journal


### PR DESCRIPTION
## Summary
- Add `.env` and `.env.*` patterns (API keys, secrets)
- Add `*.key`, `*.pem` (TLS certificates/private keys)
- Add `credentials.json`, `secrets.json` (OAuth/API credentials)
- Add `*.db-shm`, `*.db-wal`, `*.db-journal` (SQLite temp files)

## Why
Prevents accidental commits of secrets and credentials. The repo is public — any committed secret is immediately exposed. SQLite WAL/SHM files can contain unencrypted data even when the main DB is excluded.

## Test plan
- [x] No existing tracked files match these patterns
- [x] Patterns are standard and well-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)