### PR TITLE
Add error logging to hub server catch blocks

### DIFF
--- a/hub/server.js
+++ b/hub/server.js
@@ -72,7 +72,9 @@ function parseSessionLine(line) {
 				}
 			}
 		}
-	} catch { /* ignore */ }
+	} catch (e) {
+		if (!(e instanceof SyntaxError)) console.error('parseSessionLine error:', e.message);
+	}
 	return [];
 }
 
@@ -114,7 +116,7 @@ function startWatching() {
 				const pct = parseInt(fs.readFileSync('/tmp/relaygent-context-pct', 'utf-8').trim(), 10);
 				if (!isNaN(pct)) broadcastRelay({ type: 'context', pct });
 			} catch { /* no context file */ }
-		} catch { /* ignore */ }
+		} catch (e) { console.error('Session file watcher error:', e.message); }
 	});
 	console.log(`Watching: ${sessionFile}`);
 }
@@ -142,7 +144,9 @@ function startChatWatcher() {
 			if (!raw || raw === '{}') return;
 			const msg = JSON.parse(raw);
 			if (msg.id) broadcastChat({ type: 'message', data: msg });
-		} catch { /* ignore */ }
+		} catch (e) {
+			if (!(e instanceof SyntaxError)) console.error('Chat watcher error:', e.message);
+		}
 	});
 }
 


### PR DESCRIPTION
## Summary
- `parseSessionLine`: Log non-`SyntaxError` exceptions (JSON parse errors are expected and skipped, but `TypeError`/`ReferenceError` etc. indicate real bugs)
- Session file watcher: Log file I/O errors instead of silent `catch {}` — catches disk issues, permission problems, deleted session files
- Chat trigger watcher: Log non-`SyntaxError` exceptions for visibility into file read failures
- WebSocket broadcast `catch {}` blocks left as-is (per-client send errors are expected and high-frequency)

## Why
When the relay activity feed goes dark, there's currently zero diagnostic information. Every `catch {}` is a potential black hole for debugging. This makes failures visible in the hub server logs without adding noise for expected errors.

## Test plan
- [x] File under 200-line limit (171 lines)
- [x] File is syntactically valid JS
- [x] Only non-SyntaxError exceptions are logged (JSON parse failures from partial JSONL lines are expected and remain silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)