### PR TITLE
Fix: check context_too_large before incomplete in relay loop

### DIFF
--- a/harness/relay.py
+++ b/harness/relay.py
@@ -100,6 +100,16 @@ class RelayRunner:
                 time.sleep(5)
                 continue
 
+            if result.context_too_large:
+                log("Request too large — starting fresh session (not resuming)")
+                session_id = str(uuid.uuid4())
+                self.claude.session_id = session_id
+                session_established = False
+                incomplete_count = 0
+                resume_reason = ""
+                time.sleep(5)
+                continue
+
             if result.incomplete:
                 incomplete_count += 1
                 if incomplete_count > MAX_INCOMPLETE_RETRIES:
@@ -117,16 +127,6 @@ class RelayRunner:
                     session_established = True
                     resume_reason = "Continue where you left off."
                     time.sleep(delay)
-                continue
-
-            if result.context_too_large:
-                log("Request too large — starting fresh session (not resuming)")
-                session_id = str(uuid.uuid4())
-                self.claude.session_id = session_id
-                session_established = False
-                incomplete_count = 0
-                resume_reason = ""
-                time.sleep(5)
                 continue
 
             if result.exit_code != 0:


### PR DESCRIPTION
## Summary
- Moves the `context_too_large` check before `incomplete` in the relay loop
- When a request is too large, we should immediately reset to a fresh session rather than falling through to incomplete-retry logic
- The two failure modes require different recovery paths — this ordering is correct

## Test plan
- [ ] CI passes
- [ ] Verify relay handles context-too-large by spawning fresh session (not retrying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)