### PR TITLE
Fix bad image handling and DISPLAY env in subprocess

### DIFF
--- a/computer-use/linux_display.py
+++ b/computer-use/linux_display.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 
 logger = logging.getLogger(__name__)
-
+_ENV = {**os.environ, "DISPLAY": os.environ.get("DISPLAY", ":99")}
 
 def _run(args, timeout=5):
-    r = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+    r = subprocess.run(args, capture_output=True, text=True, timeout=timeout, env=_ENV)
     return r.stdout.strip()
 
 

--- a/harness/process.py
+++ b/harness/process.py
@@ -191,9 +191,9 @@ class ClaudeProcess:
         try:
             with open(LOG_FILE) as f:
                 lines = f.readlines()[log_start:]
-            if any('Request too large' in l for l in lines):
+            if any('Request too large' in l or 'Could not process image' in l for l in lines):
                 context_too_large = True
-                log('Context too large — will start fresh')
+                log('Context too large or bad image — will start fresh')
         except OSError: pass
         return ClaudeResult(exit_code=self.process.returncode or 0, hung=hung, timed_out=timed_out,
             no_output=no_output, incomplete=incomplete, context_too_large=context_too_large,

--- a/harness/relay.py
+++ b/harness/relay.py
@@ -101,7 +101,7 @@ class RelayRunner:
                 continue
 
             if result.context_too_large:
-                log("Request too large — starting fresh session (not resuming)")
+                log("Request too large or bad image — starting fresh session (not resuming)")
                 session_id = str(uuid.uuid4())
                 self.claude.session_id = session_id
                 session_established = False

--- a/harness/session.py
+++ b/harness/session.py
@@ -1,9 +1,7 @@
 """Sleep/wake handling using cached notifications file.
 
-The background notification-poller daemon maintains a cache file with
-merged fast (1s) + slow (30s, Slack/email) poll results. We read that
-file instead of hitting the notifications API directly, which avoids
-hammering the Slack API every second.
+Reads the background notification-poller cache instead of hitting the
+Slack/email APIs directly (avoids hammering APIs every second).
 """
 
 from __future__ import annotations
@@ -190,6 +188,9 @@ class SleepManager:
                 claude_result = claude.monitor(log_start)
                 if claude_result.timed_out:
                     return None
+            if claude_result.context_too_large:
+                log("Request too large or bad image during wake — returning for fresh session")
+                return claude_result
             if claude_result.exit_code != 0:
                 log(f"Crashed during wake (exit={claude_result.exit_code}), resuming...")
                 time.sleep(3)


### PR DESCRIPTION
## Summary
- **process.py**: Detect `'Could not process image'` as `context_too_large` (not just `'Request too large'`) — handles bad/corrupt image errors that also require fresh session
- **session.py**: Handle `context_too_large` during wake cycle retry loop (was missing — could cause infinite retries on bad image during wake)
- **relay.py**: Update log message to reflect both error types
- **linux_display.py**: Pass `DISPLAY` env var to all subprocess calls so `xdotool`/`wmctrl` work correctly when `DISPLAY` isn't inherited by subprocesses

## Test plan
- [ ] CI passes
- [ ] Verify bad image error triggers fresh session instead of retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)